### PR TITLE
fix: skip management cluster workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/management-cluster-aro.yml
+++ b/.github/workflows/management-cluster-aro.yml
@@ -47,7 +47,9 @@ env:
 jobs:
   management-cluster:
     name: Management Cluster (ARO/CAPZ)
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 60
 


### PR DESCRIPTION
## Description

Dependabot PRs fail the Management Cluster (ARO) workflow because GitHub
does not expose repository secrets to Dependabot-triggered runs. Since
Dependabot only updates action versions in workflow YAML files, running
the full management cluster deployment is unnecessary.

Fixes the false failure seen on PR #775 (and previously on PR #757).

## Changes Made

- Skip the `management-cluster` job when triggered by `dependabot[bot]`
  by adding `github.actor != 'dependabot[bot]'` to the existing job-level
  `if` condition

## Configuration Changes

No new environment variables.

## Additional Notes

The ROSA management cluster workflow (`management-cluster-rosa.yml`) is
already disabled (`if: false`) and not affected. No other PR-triggered
workflows require `QUAY_AUTH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to refine job execution conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->