### PR TITLE
Cache GetKubeContext() result to avoid repeated kubectl shelling (ARO-24271)

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -1096,6 +1096,12 @@ func (c *TestConfig) GetKubeContext() string {
 			c.kubeContext = fmt.Sprintf("kind-%s", c.ManagementClusterName)
 		}
 	})
+	// If the external-cluster lookup failed (transient kubectl error), the Once
+	// has fired but cached "". Fall back to a fresh lookup so callers can retry
+	// rather than getting a permanently poisoned empty context.
+	if c.IsExternalCluster() && c.kubeContext == "" {
+		return ExtractCurrentContext(c.UseKubeconfig)
+	}
 	return c.kubeContext
 }
 

--- a/test/config.go
+++ b/test/config.go
@@ -549,6 +549,14 @@ type TestConfig struct {
 	// When true and USE_KUBECONFIG is set, deploys CAPI/provider charts to external cluster.
 	// Default: false
 	DeployCharts bool
+
+	// kubeContext caches the result of GetKubeContext() so the external-cluster
+	// path does not shell out to `kubectl config current-context` on every call.
+	// kubeContextOnce guards the one-time computation. These are per-instance
+	// (not package-level) so distinct configs with different UseKubeconfig values
+	// resolve their own context correctly.
+	kubeContext     string
+	kubeContextOnce sync.Once
 }
 
 // NewTestConfig creates a new test configuration with defaults
@@ -1076,11 +1084,19 @@ func (c *TestConfig) SharedTempDir() string {
 // GetKubeContext returns the kubectl context to use for the management cluster.
 // For external clusters, extracts current-context from the kubeconfig file.
 // For Kind clusters, returns "kind-{ManagementClusterName}".
+//
+// The result is computed once and cached: the external-cluster path shells out to
+// `kubectl config current-context`, and this method is called dozens of times across
+// test phases, so caching avoids repeatedly spawning that subprocess.
 func (c *TestConfig) GetKubeContext() string {
-	if c.IsExternalCluster() {
-		return ExtractCurrentContext(c.UseKubeconfig)
-	}
-	return fmt.Sprintf("kind-%s", c.ManagementClusterName)
+	c.kubeContextOnce.Do(func() {
+		if c.IsExternalCluster() {
+			c.kubeContext = ExtractCurrentContext(c.UseKubeconfig)
+		} else {
+			c.kubeContext = fmt.Sprintf("kind-%s", c.ManagementClusterName)
+		}
+	})
+	return c.kubeContext
 }
 
 // AllControllers returns all infrastructure controllers across all providers,

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -1151,3 +1151,49 @@ func TestClusterMode_MCE_FindsMostRecentKubeconfig(t *testing.T) {
 		t.Errorf("Expected UseKubeconfig to be most recent file %q, got %q", newerFile.Name(), config.UseKubeconfig)
 	}
 }
+
+// --- GetKubeContext tests ---
+
+func TestGetKubeContext_KindFormat(t *testing.T) {
+	config := &TestConfig{ManagementClusterName: "capz-tests-stage"}
+
+	got := config.GetKubeContext()
+	want := "kind-capz-tests-stage"
+	if got != want {
+		t.Errorf("GetKubeContext() = %q, want %q", got, want)
+	}
+}
+
+func TestGetKubeContext_Cached(t *testing.T) {
+	// For a Kind cluster the context derives from ManagementClusterName.
+	// The result is cached on first call, so mutating the field afterwards
+	// must not change what GetKubeContext() returns.
+	config := &TestConfig{ManagementClusterName: "capz-tests-stage"}
+
+	first := config.GetKubeContext()
+
+	// Mutate the underlying field; a cached result should ignore this.
+	config.ManagementClusterName = "changed-name"
+
+	second := config.GetKubeContext()
+	if second != first {
+		t.Errorf("GetKubeContext() not cached: first=%q, second=%q", first, second)
+	}
+	if second != "kind-capz-tests-stage" {
+		t.Errorf("GetKubeContext() returned stale-but-wrong value %q, want cached %q", second, "kind-capz-tests-stage")
+	}
+}
+
+func TestGetKubeContext_PerInstance(t *testing.T) {
+	// The cache is per-instance: two configs must resolve independently
+	// rather than sharing a package-level cached value.
+	configA := &TestConfig{ManagementClusterName: "cluster-a"}
+	configB := &TestConfig{ManagementClusterName: "cluster-b"}
+
+	if got := configA.GetKubeContext(); got != "kind-cluster-a" {
+		t.Errorf("configA.GetKubeContext() = %q, want %q", got, "kind-cluster-a")
+	}
+	if got := configB.GetKubeContext(); got != "kind-cluster-b" {
+		t.Errorf("configB.GetKubeContext() = %q, want %q", got, "kind-cluster-b")
+	}
+}


### PR DESCRIPTION
## Description

`TestConfig.GetKubeContext()` shelled out to `kubectl config current-context`
on every call in the external-cluster path. It is invoked dozens of times
across all test phases, spawning a subprocess each time. This caches the
result so the lookup runs at most once per config instance.

JIRA: https://redhat.atlassian.net/browse/ARO-24271

## Changes Made

- Add per-instance `kubeContext` + `kubeContextOnce sync.Once` fields to `TestConfig`
- Wrap `GetKubeContext()` in `sync.Once`, caching the result on first call (per-instance so configs with different `UseKubeconfig` stay correct)
- Add a fallback guard: if `ExtractCurrentContext` returned `""` on the first call (transient `kubectl` failure), subsequent calls retry the lookup rather than returning the permanently-cached empty string
- Add tests covering the Kind context format, caching behavior, and per-instance isolation

## Configuration Changes

_None — no new environment variables._

## Additional Notes

- Verified with `go build`, `go vet`, and the config unit tests (including `-race`).
- The `kubeContextOnce` field means `TestConfig` must always be used as a pointer (it already is — `NewTestConfig()` returns `*TestConfig` and all methods use pointer receivers; `go vet`'s copylock check passes).
