### PR TITLE
Add workload identity auth mode and tests (ARO-24292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,28 @@ export AZURE_TENANT_ID=$(az account show --query tenantId -o tsv)
 export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 ```
 
+#### Option 3: Workload Identity (Federated Managed Identities)
+
+For clusters configured with an OIDC issuer, the test suite can drive YAML generation
+using federated user-assigned managed identities instead of a service principal secret.
+This mode is **opt-in** and detected when all three of the following are set:
+
+```bash
+export USER_ASSIGNED_IDENTITY_ASO=<aso-identity-name>      # user-assigned identity for ASO
+export USER_ASSIGNED_IDENTITY_ARO=<aro-identity-name>      # user-assigned identity for ARO
+export OICD_RESOURCE_GROUP=<oidc-issuer-resource-group>    # resource group hosting the OIDC issuer
+export ENV=int                                             # optional: environment selector passed to gen.sh
+```
+
+Notes:
+- These variable names (including the `OICD` spelling) match the existing `gen.sh` support
+  in cluster-api-installer, which keys off `KIND_CLUSTER_NAME` to export them.
+- When set, `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` are **not** required (as with Azure CLI auth).
+- An active Azure session (e.g. `az login`) is still needed for control-plane operations.
+- Check Dependencies (Phase 01) validates the identity/resource-group names for RFC 1123
+  compliance via `TestCheckDependencies_AzureWorkloadIdentity`; if none are set, the check is skipped.
+- Setting only some of the three variables is treated as a misconfiguration and fails early.
+
 ### Repository Configuration
 - `ARO_REPO_URL` - cluster-api-installer URL (default: RadekCap/cluster-api-installer)
 - `ARO_REPO_BRANCH` - Branch to use (default: `ARO-ASO`)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ jq --version
 - Authenticated via one of:
   - **Service principal** (recommended for CI): Set `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`
   - **Azure CLI** (for development): Run `az login`
+  - **Workload identity** (federated managed identities): Set `USER_ASSIGNED_IDENTITY_ASO`, `USER_ASSIGNED_IDENTITY_ARO`, and `OICD_RESOURCE_GROUP` (see [CLAUDE.md](CLAUDE.md#option-3-workload-identity-federated-managed-identities))
 
 ## Configuration
 
@@ -211,6 +212,11 @@ Example: `CLUSTER_DEPLOYMENT_TIMEOUT=90m make _deploy-crs` (sets Go step timeout
    export AZURE_CLIENT_SECRET=<your-client-secret>
    export AZURE_TENANT_ID=<your-tenant-id>
    export AZURE_SUBSCRIPTION_ID=<your-subscription-id>
+
+   # Option C: Workload Identity (federated managed identities)
+   export USER_ASSIGNED_IDENTITY_ASO=<aso-identity-name>
+   export USER_ASSIGNED_IDENTITY_ARO=<aro-identity-name>
+   export OICD_RESOURCE_GROUP=<oidc-issuer-resource-group>
    ```
 
 3. **Run check dependencies tests**:

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -441,6 +441,13 @@ func TestCheckDependencies_AzureAuthentication(t *testing.T) {
 	case AzureAuthModeCLI:
 		t.Log("Azure authentication via CLI is valid")
 
+	case AzureAuthModeWorkloadIdentity:
+		// Workload identity relies on federated managed identities plus an active Azure
+		// session (e.g. az login) for the control-plane operations gen.sh performs.
+		// The dedicated TestCheckDependencies_AzureWorkloadIdentity test validates the
+		// identity variables themselves.
+		t.Log("Azure authentication via workload identity is configured")
+
 	case AzureAuthModeNone:
 		t.Errorf("No Azure authentication available.\n\n" +
 			"Please authenticate using one of these methods:\n\n" +
@@ -454,6 +461,75 @@ func TestCheckDependencies_AzureAuthentication(t *testing.T) {
 			"  az ad sp create-for-rbac --name <name> --role Contributor --scopes /subscriptions/<subscription-id>")
 		return
 	}
+}
+
+// TestCheckDependencies_AzureWorkloadIdentity validates the Azure workload identity
+// configuration when it is in use. Workload identity is opt-in: if none of the
+// USER_ASSIGNED_IDENTITY_ASO / USER_ASSIGNED_IDENTITY_ARO / OICD_RESOURCE_GROUP
+// variables are set, the test is skipped (the suite falls back to service principal
+// or Azure CLI auth). When some but not all are set, the configuration is incomplete
+// and the test fails with a clear message. When all are set, the identity and resource
+// group names are validated for RFC 1123 compliance so misconfiguration is caught early
+// rather than during deployment.
+func TestCheckDependencies_AzureWorkloadIdentity(t *testing.T) {
+	config := NewTestConfig()
+	if !config.HasProvider("aro") {
+		t.Skip("Skipping Azure workload identity check (provider is not aro)")
+	}
+
+	// Map of env var name -> value, in the order gen.sh expects them.
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"USER_ASSIGNED_IDENTITY_ASO", config.AzureUserAssignedIdentityASO},
+		{"USER_ASSIGNED_IDENTITY_ARO", config.AzureUserAssignedIdentityARO},
+		{"OICD_RESOURCE_GROUP", config.AzureOIDCResourceGroup},
+	}
+
+	var setVars, missingVars []string
+	for _, v := range required {
+		if v.value != "" {
+			setVars = append(setVars, v.name)
+		} else {
+			missingVars = append(missingVars, v.name)
+		}
+	}
+
+	// Not configured at all: workload identity is optional, so skip.
+	if len(setVars) == 0 {
+		t.Skip("Workload identity not configured (USER_ASSIGNED_IDENTITY_ASO/ARO, OICD_RESOURCE_GROUP unset) - skipping")
+	}
+
+	// Partially configured: this is almost certainly a mistake, so fail loudly.
+	if len(missingVars) > 0 {
+		t.Fatalf("Incomplete Azure workload identity configuration.\n"+
+			"Set: %v\n"+
+			"Missing: %v\n\n"+
+			"Workload identity requires all of the following to be set together:\n"+
+			"  export USER_ASSIGNED_IDENTITY_ASO=<aso-identity-name>\n"+
+			"  export USER_ASSIGNED_IDENTITY_ARO=<aro-identity-name>\n"+
+			"  export OICD_RESOURCE_GROUP=<oidc-issuer-resource-group>",
+			setVars, missingVars)
+	}
+
+	// Fully configured: validate the names so a bad value fails here, not mid-deployment.
+	for _, v := range required {
+		t.Run(v.name, func(t *testing.T) {
+			if err := ValidateRFC1123Name(v.value, v.name); err != nil {
+				t.Errorf("%s is not a valid RFC 1123 name: %v", v.name, err)
+				return
+			}
+			t.Logf("%s is set and valid", v.name)
+		})
+	}
+
+	// ENV is optional; report it so users can confirm which gen.sh environment is selected.
+	if config.AzureWorkloadIdentityEnv != "" {
+		t.Logf("Workload identity environment (ENV): %s", config.AzureWorkloadIdentityEnv)
+	}
+
+	t.Logf("Azure workload identity configuration is complete: %s", GetAzureAuthDescription(AzureAuthModeWorkloadIdentity))
 }
 
 // TestCheckDependencies_AzureEnvironment validates required Azure environment variables.

--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -50,7 +50,9 @@ func TestInfrastructure_01_ValidateCredentials(t *testing.T) {
 		}
 		authMode := DetectAzureAuthMode(t)
 		t.Logf("Azure auth mode: %s", GetAzureAuthDescription(authMode))
-		if authMode == AzureAuthModeCLI {
+		// Neither Azure CLI nor workload identity uses a service principal client
+		// secret, so those variables are not required for YAML generation in those modes.
+		if authMode == AzureAuthModeCLI || authMode == AzureAuthModeWorkloadIdentity {
 			spOnlyVars["AZURE_CLIENT_ID"] = true
 			spOnlyVars["AZURE_CLIENT_SECRET"] = true
 		}
@@ -233,6 +235,19 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 
 	if config.AzureSubscriptionName != "" {
 		SetEnvVar(t, "AZURE_SUBSCRIPTION_NAME", config.AzureSubscriptionName)
+	}
+
+	// Pass workload identity configuration through to gen.sh when set, so federated
+	// managed-identity auth works regardless of gen.sh's own KIND_CLUSTER_NAME branch.
+	// These are only forwarded when all three are present (a complete workload identity setup).
+	if HasWorkloadIdentityCredentials() {
+		SetEnvVar(t, "USER_ASSIGNED_IDENTITY_ASO", config.AzureUserAssignedIdentityASO)
+		SetEnvVar(t, "USER_ASSIGNED_IDENTITY_ARO", config.AzureUserAssignedIdentityARO)
+		SetEnvVar(t, "OICD_RESOURCE_GROUP", config.AzureOIDCResourceGroup)
+		if config.AzureWorkloadIdentityEnv != "" {
+			SetEnvVar(t, "ENV", config.AzureWorkloadIdentityEnv)
+		}
+		PrintToTTY("Using Azure workload identity for YAML generation\n")
 	}
 
 	PrintToTTY("Workload cluster namespace: %s\n", config.WorkloadClusterNamespace)

--- a/test/config.go
+++ b/test/config.go
@@ -471,23 +471,30 @@ type TestConfig struct {
 	RepoDir    string
 
 	// Cluster configuration
-	ManagementClusterName    string
-	WorkloadClusterName      string
-	ClusterNamePrefix        string // Used as CS_CLUSTER_NAME for YAML generation
-	NamePrefix               string // NAME_PREFIX used for Azure resource naming (Key Vault, node pools); passed to YAML generation
-	OCPVersion               string
-	OCPVersionMP             string // Full x.y.z OpenShift version for MachinePool workers (from OCP_VERSION_MP env var)
-	Region                   string
-	AzureSubscriptionName    string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
-	Environment              string
-	CAPIUser                 string            // User identifier for CAPI resources (from CAPI_USER env var)
-	WorkloadClusterNamespace string            // Namespace for workload cluster resources on management cluster (unique per test run)
-	TestLabelPrefix          string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
-	TestRunID                string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
-	ResourceTags             map[string]string // Tags applied to all created cloud resources (Azure RGs, AWS stacks/VPCs) for ownership tracking and cleanup
-	ResourceGroupName        string            // Azure resource group name (env: RESOURCEGROUPNAME, default: ${WorkloadClusterName}-${runID}-resgroup)
-	CAPINamespace            string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
-	CAPZNamespace            string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
+	ManagementClusterName string
+	WorkloadClusterName   string
+	ClusterNamePrefix     string // Used as CS_CLUSTER_NAME for YAML generation
+	NamePrefix            string // NAME_PREFIX used for Azure resource naming (Key Vault, node pools); passed to YAML generation
+	OCPVersion            string
+	OCPVersionMP          string // Full x.y.z OpenShift version for MachinePool workers (from OCP_VERSION_MP env var)
+	Region                string
+	AzureSubscriptionName string // Azure subscription name (from AZURE_SUBSCRIPTION_NAME env var)
+	// Workload identity configuration (optional). When these are set, gen.sh wires ASO/ARO
+	// to federated user-assigned managed identities instead of a service principal secret.
+	// See DetectAzureAuthMode / AzureAuthModeWorkloadIdentity.
+	AzureUserAssignedIdentityASO string // USER_ASSIGNED_IDENTITY_ASO: user-assigned identity for ASO
+	AzureUserAssignedIdentityARO string // USER_ASSIGNED_IDENTITY_ARO: user-assigned identity for ARO
+	AzureOIDCResourceGroup       string // OICD_RESOURCE_GROUP: resource group hosting the OIDC issuer
+	AzureWorkloadIdentityEnv     string // ENV: environment selector passed to gen.sh for workload identity (e.g. "int")
+	Environment                  string
+	CAPIUser                     string            // User identifier for CAPI resources (from CAPI_USER env var)
+	WorkloadClusterNamespace     string            // Namespace for workload cluster resources on management cluster (unique per test run)
+	TestLabelPrefix              string            // Provider-specific label prefix for test namespaces (e.g., "capz-test" for ARO, "capa-test" for ROSA)
+	TestRunID                    string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
+	ResourceTags                 map[string]string // Tags applied to all created cloud resources (Azure RGs, AWS stacks/VPCs) for ownership tracking and cleanup
+	ResourceGroupName            string            // Azure resource group name (env: RESOURCEGROUPNAME, default: ${WorkloadClusterName}-${runID}-resgroup)
+	CAPINamespace                string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
+	CAPZNamespace                string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
 
 	// Management cluster mode
 	// ClusterMode specifies the management cluster deployment mode ("kind" or "mce").
@@ -724,23 +731,27 @@ func NewTestConfig() *TestConfig {
 		RepoDir:    getDefaultRepoDir(),
 
 		// Cluster defaults
-		ManagementClusterName:    GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
-		WorkloadClusterName:      workloadClusterName,
-		ClusterNamePrefix:        prefix,
-		NamePrefix:               GetEnvOrDefault("NAME_PREFIX", ""),
-		OCPVersion:               GetEnvOrDefault("OCP_VERSION", "4.20"),
-		OCPVersionMP:             GetEnvOrDefault("OCP_VERSION_MP", "4.20.17"),
-		Region:                   GetEnvOrDefault(regionEnvVar, defaultRegion),
-		AzureSubscriptionName:    os.Getenv("AZURE_SUBSCRIPTION_NAME"),
-		Environment:              environment,
-		CAPIUser:                 capiUser,
-		WorkloadClusterNamespace: getWorkloadClusterNamespace(testLabelPrefix),
-		TestLabelPrefix:          testLabelPrefix,
-		TestRunID:                testRunID,
-		ResourceTags:             resourceTags,
-		ResourceGroupName:        rgName,
-		CAPINamespace:            getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
-		CAPZNamespace:            providerNamespace,
+		ManagementClusterName:        GetEnvOrDefault("MANAGEMENT_CLUSTER_NAME", defaultMgmtCluster),
+		WorkloadClusterName:          workloadClusterName,
+		ClusterNamePrefix:            prefix,
+		NamePrefix:                   GetEnvOrDefault("NAME_PREFIX", ""),
+		OCPVersion:                   GetEnvOrDefault("OCP_VERSION", "4.20"),
+		OCPVersionMP:                 GetEnvOrDefault("OCP_VERSION_MP", "4.20.17"),
+		Region:                       GetEnvOrDefault(regionEnvVar, defaultRegion),
+		AzureSubscriptionName:        os.Getenv("AZURE_SUBSCRIPTION_NAME"),
+		AzureUserAssignedIdentityASO: os.Getenv("USER_ASSIGNED_IDENTITY_ASO"),
+		AzureUserAssignedIdentityARO: os.Getenv("USER_ASSIGNED_IDENTITY_ARO"),
+		AzureOIDCResourceGroup:       os.Getenv("OICD_RESOURCE_GROUP"),
+		AzureWorkloadIdentityEnv:     os.Getenv("ENV"),
+		Environment:                  environment,
+		CAPIUser:                     capiUser,
+		WorkloadClusterNamespace:     getWorkloadClusterNamespace(testLabelPrefix),
+		TestLabelPrefix:              testLabelPrefix,
+		TestRunID:                    testRunID,
+		ResourceTags:                 resourceTags,
+		ResourceGroupName:            rgName,
+		CAPINamespace:                getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
+		CAPZNamespace:                providerNamespace,
 
 		// Management cluster mode
 		ClusterMode: clusterMode,

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -3625,13 +3625,26 @@ const (
 	// AzureAuthModeCLI indicates authentication via Azure CLI (az login).
 	AzureAuthModeCLI AzureAuthMode = "cli"
 
+	// AzureAuthModeWorkloadIdentity indicates authentication via Azure workload identity
+	// (user-assigned managed identities federated with an OIDC issuer). This is signalled
+	// by USER_ASSIGNED_IDENTITY_ASO + USER_ASSIGNED_IDENTITY_ARO + OICD_RESOURCE_GROUP,
+	// which gen.sh consumes to wire ASO/ARO to their federated identities instead of a
+	// service principal client secret.
+	AzureAuthModeWorkloadIdentity AzureAuthMode = "workload-identity"
+
 	// AzureAuthModeNone indicates no valid authentication is available.
 	AzureAuthModeNone AzureAuthMode = "none"
 )
 
 // DetectAzureAuthMode determines which authentication method is available.
-// It checks for service principal credentials first (preferred for CI/automation),
-// then falls back to Azure CLI authentication.
+// Workload identity is checked first (it is opt-in and only set intentionally),
+// then service principal credentials (preferred for CI/automation), then it falls
+// back to Azure CLI authentication.
+//
+// Workload identity authentication requires:
+// - USER_ASSIGNED_IDENTITY_ASO
+// - USER_ASSIGNED_IDENTITY_ARO
+// - OICD_RESOURCE_GROUP
 //
 // Service principal authentication requires:
 // - AZURE_CLIENT_ID
@@ -3643,7 +3656,15 @@ const (
 func DetectAzureAuthMode(t *testing.T) AzureAuthMode {
 	t.Helper()
 
-	// Check for service principal credentials first
+	// Check for workload identity configuration first. These variables are only ever
+	// set on purpose to opt into federated managed-identity auth, so their presence is
+	// the strongest signal of intent and must win over any service principal fallback.
+	if HasWorkloadIdentityCredentials() {
+		t.Log("Workload identity configuration detected (USER_ASSIGNED_IDENTITY_ASO, USER_ASSIGNED_IDENTITY_ARO, OICD_RESOURCE_GROUP)")
+		return AzureAuthModeWorkloadIdentity
+	}
+
+	// Check for service principal credentials next
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 	tenantID := os.Getenv("AZURE_TENANT_ID")
@@ -3669,6 +3690,16 @@ func HasServicePrincipalCredentials() bool {
 	return os.Getenv("AZURE_CLIENT_ID") != "" &&
 		os.Getenv("AZURE_CLIENT_SECRET") != "" &&
 		os.Getenv("AZURE_TENANT_ID") != ""
+}
+
+// HasWorkloadIdentityCredentials returns true if the workload identity environment
+// variables consumed by gen.sh are all set. This is a quick presence check only; it
+// does not validate that the referenced managed identities or OIDC resource group
+// actually exist in Azure.
+func HasWorkloadIdentityCredentials() bool {
+	return os.Getenv("USER_ASSIGNED_IDENTITY_ASO") != "" &&
+		os.Getenv("USER_ASSIGNED_IDENTITY_ARO") != "" &&
+		os.Getenv("OICD_RESOURCE_GROUP") != ""
 }
 
 // ValidateServicePrincipalCredentials validates that service principal credentials can authenticate.
@@ -3729,6 +3760,8 @@ func GetAzureAuthDescription(mode AzureAuthMode) string {
 		return "service principal (AZURE_CLIENT_ID/AZURE_CLIENT_SECRET)"
 	case AzureAuthModeCLI:
 		return "Azure CLI (az login)"
+	case AzureAuthModeWorkloadIdentity:
+		return "workload identity (USER_ASSIGNED_IDENTITY_ASO/USER_ASSIGNED_IDENTITY_ARO)"
 	default:
 		return "no authentication"
 	}

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -3255,6 +3255,91 @@ func TestHasServicePrincipalCredentials(t *testing.T) {
 	}
 }
 
+// TestHasWorkloadIdentityCredentials tests the HasWorkloadIdentityCredentials function.
+func TestHasWorkloadIdentityCredentials(t *testing.T) {
+	tests := []struct {
+		name        string
+		identityASO string
+		identityARO string
+		oidcRG      string
+		expected    bool
+	}{
+		{
+			name:        "all workload identity vars set",
+			identityASO: "aso-identity",
+			identityARO: "aro-identity",
+			oidcRG:      "oidc-rg",
+			expected:    true,
+		},
+		{
+			name:        "missing ASO identity",
+			identityASO: "",
+			identityARO: "aro-identity",
+			oidcRG:      "oidc-rg",
+			expected:    false,
+		},
+		{
+			name:        "missing ARO identity",
+			identityASO: "aso-identity",
+			identityARO: "",
+			oidcRG:      "oidc-rg",
+			expected:    false,
+		},
+		{
+			name:        "missing OIDC resource group",
+			identityASO: "aso-identity",
+			identityARO: "aro-identity",
+			oidcRG:      "",
+			expected:    false,
+		},
+		{
+			name:        "all empty",
+			identityASO: "",
+			identityARO: "",
+			oidcRG:      "",
+			expected:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Save original values
+			origASO := os.Getenv("USER_ASSIGNED_IDENTITY_ASO")
+			origARO := os.Getenv("USER_ASSIGNED_IDENTITY_ARO")
+			origRG := os.Getenv("OICD_RESOURCE_GROUP")
+
+			// Restore original values after test
+			t.Cleanup(func() {
+				_ = os.Setenv("USER_ASSIGNED_IDENTITY_ASO", origASO)
+				_ = os.Setenv("USER_ASSIGNED_IDENTITY_ARO", origARO)
+				_ = os.Setenv("OICD_RESOURCE_GROUP", origRG)
+			})
+
+			// Set test values
+			if tc.identityASO != "" {
+				_ = os.Setenv("USER_ASSIGNED_IDENTITY_ASO", tc.identityASO)
+			} else {
+				_ = os.Unsetenv("USER_ASSIGNED_IDENTITY_ASO")
+			}
+			if tc.identityARO != "" {
+				_ = os.Setenv("USER_ASSIGNED_IDENTITY_ARO", tc.identityARO)
+			} else {
+				_ = os.Unsetenv("USER_ASSIGNED_IDENTITY_ARO")
+			}
+			if tc.oidcRG != "" {
+				_ = os.Setenv("OICD_RESOURCE_GROUP", tc.oidcRG)
+			} else {
+				_ = os.Unsetenv("OICD_RESOURCE_GROUP")
+			}
+
+			result := HasWorkloadIdentityCredentials()
+			if result != tc.expected {
+				t.Errorf("HasWorkloadIdentityCredentials() = %v, expected %v", result, tc.expected)
+			}
+		})
+	}
+}
+
 // TestGetAzureAuthDescription tests the GetAzureAuthDescription function.
 func TestGetAzureAuthDescription(t *testing.T) {
 	tests := []struct {
@@ -3268,6 +3353,10 @@ func TestGetAzureAuthDescription(t *testing.T) {
 		{
 			mode:     AzureAuthModeCLI,
 			expected: "Azure CLI (az login)",
+		},
+		{
+			mode:     AzureAuthModeWorkloadIdentity,
+			expected: "workload identity (USER_ASSIGNED_IDENTITY_ASO/USER_ASSIGNED_IDENTITY_ARO)",
 		},
 		{
 			mode:     AzureAuthModeNone,
@@ -3297,6 +3386,9 @@ func TestAzureAuthModeConstants(t *testing.T) {
 	}
 	if AzureAuthModeCLI != "cli" {
 		t.Errorf("AzureAuthModeCLI = %q, expected 'cli'", AzureAuthModeCLI)
+	}
+	if AzureAuthModeWorkloadIdentity != "workload-identity" {
+		t.Errorf("AzureAuthModeWorkloadIdentity = %q, expected 'workload-identity'", AzureAuthModeWorkloadIdentity)
 	}
 	if AzureAuthModeNone != "none" {
 		t.Errorf("AzureAuthModeNone = %q, expected 'none'", AzureAuthModeNone)


### PR DESCRIPTION
## Description

Add a third Azure authentication mode to the CAPZ test suite: **workload identity**
via federated user-assigned managed identities, alongside the existing service
principal and Azure CLI modes. The implementation is opt-in and WI-agnostic — tests
skip gracefully when workload identity is not configured, so existing runs are
unaffected.

JIRA: https://redhat.atlassian.net/browse/ARO-24292

## Changes Made

- `test/helpers.go`: new `AzureAuthModeWorkloadIdentity` enum, `HasWorkloadIdentityCredentials()` helper, and detection/description wiring (WI is detected first, since it is opt-in)
- `test/config.go`: config fields for `USER_ASSIGNED_IDENTITY_ASO/ARO`, `OICD_RESOURCE_GROUP`, and `ENV`
- `test/04_generate_yamls_test.go`: forward workload identity vars to `gen.sh` when fully set; skip service-principal-only vars in this mode
- `test/01_check_dependencies_test.go`: gated `TestCheckDependencies_AzureWorkloadIdentity` (skips when unset, fails on partial config, RFC-1123-validates names when complete); WI case added to the auth switch
- `test/helpers_test.go`: unit tests for the new helper, description, and constant
- `CLAUDE.md`, `README.md`: documented "Option 3: Workload Identity" and the env vars

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| `USER_ASSIGNED_IDENTITY_ASO` | User-assigned managed identity for ASO | (unset) |
| `USER_ASSIGNED_IDENTITY_ARO` | User-assigned managed identity for ARO | (unset) |
| `OICD_RESOURCE_GROUP` | Resource group hosting the OIDC issuer | (unset) |
| `ENV` | Environment selector passed to gen.sh (optional) | (unset) |

## Additional Notes

- Variable names (including the `OICD` spelling) match the existing `gen.sh` support in cluster-api-installer.
- Detection keys on the three distinctive identity vars, not the generic `ENV` (which is only forwarded, never used for detection).
- The ticket's open question — whether the workload-identity kind cluster is pre-provisioned or created in-suite (to confirm with Martin) — is intentionally out of scope here; this PR is agnostic to that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)