### PR TITLE
fix: use fully-qualified clusters.cluster.x-k8s.io for CAPI Cluster queries (ARO-29248)

### DIFF
--- a/scripts/monitor-cluster-json.sh
+++ b/scripts/monitor-cluster-json.sh
@@ -29,7 +29,10 @@ fi
 # Get Cluster
 # Capture both stdout and stderr separately to distinguish errors
 KUBECTL_STDERR=$(mktemp)
-CLUSTER_JSON=$("${KUBECTL_CMD[@]}" get cluster "$CLUSTER_NAME" -n "$NAMESPACE" -o json 2>"$KUBECTL_STDERR")
+# Use the fully-qualified resource name so the query is unambiguous even when
+# another CRD also registers a "Cluster" kind (e.g. clusters.submariner.io on
+# ACM/MCE clusters). See ARO-29248.
+CLUSTER_JSON=$("${KUBECTL_CMD[@]}" get clusters.cluster.x-k8s.io "$CLUSTER_NAME" -n "$NAMESPACE" -o json 2>"$KUBECTL_STDERR")
 KUBECTL_EXIT_CODE=$?
 KUBECTL_ERROR=$(cat "$KUBECTL_STDERR")
 rm -f "$KUBECTL_STDERR"

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -455,7 +455,7 @@ func TestDeployment_MonitorCluster(t *testing.T) {
 	PrintToTTY("\nChecking if cluster resource exists...\n")
 	t.Logf("Checking for cluster resource: %s (namespace: %s)", provisionedClusterName, config.WorkloadClusterNamespace)
 
-	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace, "get", "cluster", provisionedClusterName)
+	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace, "get", capiClusterResource, provisionedClusterName)
 	if err != nil {
 		PrintToTTY("⚠️  Cluster resource not found (may not be deployed yet)\n\n")
 		t.Skipf("Cluster resource not found (may not be deployed yet): %v", err)
@@ -570,7 +570,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				"Troubleshooting steps:\n"+
 				"  1. Check ControlPlane status: kubectl --context %s -n %s get %s %s -o yaml\n"+
 				"  2. Check MachinePool status: kubectl --context %s -n %s get machinepool %s -o yaml\n"+
-				"  3. Check cluster conditions: kubectl --context %s -n %s get cluster %s -o yaml\n"+
+				"  3. Check cluster conditions: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml\n"+
 				"  4. Check controller logs: kubectl --context %s -n capz-system logs -l control-plane=controller-manager --tail=100\n\n"+
 				"To increase timeout: export DEPLOYMENT_TIMEOUT=60m",
 				elapsed.Round(time.Second),
@@ -608,7 +608,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 			PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
 			t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
 				"Check cluster status:\n"+
-				"  kubectl --context %s -n %s get cluster %s -o yaml",
+				"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 				context, config.WorkloadClusterNamespace, provisionedClusterName)
 		}
 
@@ -1151,7 +1151,7 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 
 	PrintToTTY("\n=== Waiting for Cluster.Initialization.InfrastructureProvisioned ===\n")
 	PrintToTTY("Cluster: %s | Namespace: %s\n", provisionedClusterName, config.WorkloadClusterNamespace)
-	PrintToTTY("Command: kubectl --context %s -n %s get cluster %s -o jsonpath={.status.initialization.infrastructureProvisioned}\n\n",
+	PrintToTTY("Command: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o jsonpath={.status.initialization.infrastructureProvisioned}\n\n",
 		context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 	for {
@@ -1161,7 +1161,7 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 			CollectAndDumpInfraDiagnostics(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 			t.Fatalf("Timeout after %v waiting for cluster.status.initialization.infrastructureProvisioned=true.\n"+
-				"  kubectl --context %s -n %s get cluster %s -o yaml",
+				"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace, provisionedClusterName)
 		}
 
@@ -1190,7 +1190,7 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 				PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
 				t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
 					"Check cluster status:\n"+
-					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 					context, config.WorkloadClusterNamespace, provisionedClusterName)
 			}
 			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
@@ -1198,7 +1198,7 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 				PrintToTTY("   %v\n\n", failErr)
 				t.Fatalf("Permanent failure in Cluster conditions — deployment cannot recover.\n%v\n\n"+
 					"Check cluster status:\n"+
-					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			}
 		}
@@ -1228,7 +1228,7 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 
 	PrintToTTY("\n=== Waiting for CAPI Cluster.InfrastructureReady ===\n")
 	PrintToTTY("Cluster: %s | Namespace: %s\n", provisionedClusterName, config.WorkloadClusterNamespace)
-	PrintToTTY("Command: kubectl --context %s -n %s get cluster %s -o jsonpath={.status.conditions[?(@.type=='InfrastructureReady')].status}\n\n",
+	PrintToTTY("Command: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o jsonpath={.status.conditions[?(@.type=='InfrastructureReady')].status}\n\n",
 		context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 	for {
@@ -1238,7 +1238,7 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 			CollectAndDumpInfraDiagnostics(t, context, config.WorkloadClusterNamespace, provisionedClusterName)
 
 			t.Fatalf("Timeout after %v waiting for Cluster InfrastructureReady=True.\n"+
-				"  kubectl --context %s -n %s get cluster %s -o yaml",
+				"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 				elapsed.Round(time.Second), context, config.WorkloadClusterNamespace, provisionedClusterName)
 		}
 
@@ -1267,7 +1267,7 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 				PrintToTTY("\n❌ Cluster phase is Failed — aborting early\n\n")
 				t.Fatalf("Cluster phase is 'Failed' — deployment cannot recover.\n\n"+
 					"Check cluster status:\n"+
-					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 					context, config.WorkloadClusterNamespace, provisionedClusterName)
 			}
 			if failErr := CheckK8sConditionsForPermanentFailure(data.Cluster.Conditions); failErr != nil {
@@ -1275,7 +1275,7 @@ func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 				PrintToTTY("   %v\n\n", failErr)
 				t.Fatalf("Permanent failure in Cluster conditions — deployment cannot recover.\n%v\n\n"+
 					"Check cluster status:\n"+
-					"  kubectl --context %s -n %s get cluster %s -o yaml",
+					"  kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml",
 					failErr, context, config.WorkloadClusterNamespace, provisionedClusterName)
 			}
 		}

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -33,7 +33,7 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 
 	// Check if cluster exists before attempting deletion
 	_, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace,
-		"get", "cluster", provisionedClusterName)
+		"get", capiClusterResource, provisionedClusterName)
 	if err != nil {
 		PrintToTTY("⚠️  Cluster '%s' not found in namespace '%s'\n", provisionedClusterName, config.WorkloadClusterNamespace)
 		t.Skipf("Cluster '%s' not found (may not have been deployed or already deleted)", provisionedClusterName)
@@ -78,7 +78,7 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 	// Use --wait=false to return immediately so the next test can monitor deletion progress
 	PrintToTTY("🗑️  Deleting Cluster resource...\n")
 	output, err := RunCommand(t, "kubectl", "--context", context, "-n", config.WorkloadClusterNamespace,
-		"delete", "cluster", provisionedClusterName, "--wait=false")
+		"delete", capiClusterResource, provisionedClusterName, "--wait=false")
 	if err != nil {
 		PrintToTTY("❌ Failed to delete cluster: %v\n", err)
 		PrintToTTY("Output: %s\n\n", output)
@@ -195,8 +195,8 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 
 			t.Errorf("Timeout waiting for cluster '%s' to be deleted after %v.\n\n"+
 				"Troubleshooting steps:\n"+
-				"  1. Check cluster status: kubectl --context %s -n %s get cluster %s -o yaml\n"+
-				"  2. Check for stuck finalizers: kubectl --context %s -n %s get cluster %s -o jsonpath='{.metadata.finalizers}'\n"+
+				"  1. Check cluster status: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml\n"+
+				"  2. Check for stuck finalizers: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o jsonpath='{.metadata.finalizers}'\n"+
 				"  3. Check remaining CAPI resources: kubectl --context %s -n %s get %s,machinepool\n"+
 				"%s\n"+
 				"Common causes:\n"+

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -4714,13 +4714,13 @@ func FormatMismatchedClustersError(mismatched []string, expectedClusterName, nam
 
 	// Single cluster cleanup
 	if len(mismatched) == 1 {
-		fmt.Fprintf(&sb, "  kubectl delete cluster %s -n %s\n\n", mismatched[0], namespace)
+		fmt.Fprintf(&sb, "  kubectl delete %s %s -n %s\n\n", capiClusterResource, mismatched[0], namespace)
 	} else {
 		// Multiple clusters
 		sb.WriteString("  # Delete specific cluster:\n")
-		fmt.Fprintf(&sb, "  kubectl delete cluster %s -n %s\n\n", mismatched[0], namespace)
+		fmt.Fprintf(&sb, "  kubectl delete %s %s -n %s\n\n", capiClusterResource, mismatched[0], namespace)
 		sb.WriteString("  # Or delete all clusters in namespace:\n")
-		fmt.Fprintf(&sb, "  kubectl delete cluster --all -n %s\n\n", namespace)
+		fmt.Fprintf(&sb, "  kubectl delete %s --all -n %s\n\n", capiClusterResource, namespace)
 	}
 
 	sb.WriteString("  # Or use make clean for complete cleanup:\n")

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -16,6 +16,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// capiClusterResource is the fully-qualified name of the CAPI Cluster resource.
+// It must be used for all `kubectl get`/`kubectl delete` calls that target CAPI
+// Cluster CRs so the query stays unambiguous even when another CRD registers a
+// "Cluster" kind (e.g. clusters.submariner.io on ACM/MCE clusters). Using the
+// bare "cluster" name resolves to the wrong CRD in those environments. See
+// ARO-29248.
+const capiClusterResource = "clusters.cluster.x-k8s.io"
+
 // ClonedRepository represents information about a cloned git repository.
 type ClonedRepository struct {
 	URL    string // Repository URL (e.g., "https://github.com/RadekCap/cluster-api-installer")
@@ -2593,7 +2601,7 @@ func FormatNetworkError(info *NetworkErrorInfo) string {
 func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {
 	t.Helper()
 
-	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", "cluster", clusterName)
+	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext, "-n", namespace, "get", capiClusterResource, clusterName)
 	if err != nil {
 		errText := strings.ToLower(output + " " + err.Error())
 		if strings.Contains(errText, "not found") || strings.Contains(errText, "no resources found") {
@@ -3845,7 +3853,7 @@ func GetDeletionResourceStatus(t *testing.T, kubeContext, namespace, clusterName
 
 		// Query finalizers directly from the cluster resource
 		finalizerOutput, finErr := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-			"-n", namespace, "get", "cluster", clusterName,
+			"-n", namespace, "get", capiClusterResource, clusterName,
 			"-o", "jsonpath={.metadata.finalizers}",
 			"--request-timeout=10s")
 		if finErr == nil && strings.TrimSpace(finalizerOutput) != "" {
@@ -4624,7 +4632,7 @@ func GetExistingClusterNames(t *testing.T, kubeContext, namespace string) ([]str
 
 	// Get all Cluster resources in the namespace
 	output, err := RunCommandQuiet(t, "kubectl", "--context", kubeContext,
-		"-n", namespace, "get", "cluster", "-o", "jsonpath={.items[*].metadata.name}")
+		"-n", namespace, "get", capiClusterResource, "-o", "jsonpath={.items[*].metadata.name}")
 
 	if err != nil {
 		// Check if the error is because CRD doesn't exist (expected on fresh clusters)

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -4097,7 +4097,7 @@ func TestFormatMismatchedClustersError(t *testing.T) {
 				"EXISTING CLUSTER RESOURCES DETECTED",
 				"cateb-stage",
 				"catek-stage",
-				"kubectl delete cluster cateb-stage -n default",
+				"kubectl delete clusters.cluster.x-k8s.io cateb-stage -n default",
 				"make clean",
 			},
 		},
@@ -4109,7 +4109,7 @@ func TestFormatMismatchedClustersError(t *testing.T) {
 			wantContains: []string{
 				"cateb-stage",
 				"old-cluster",
-				"kubectl delete cluster --all -n test-ns",
+				"kubectl delete clusters.cluster.x-k8s.io --all -n test-ns",
 				"CAPI_USER was changed",
 			},
 		},


### PR DESCRIPTION
## Description

On ACM/MCE clusters, Submariner registers its own `Cluster` kind
(`clusters.submariner.io`), so the unqualified `kubectl get cluster` is
ambiguous and resolves to the Submariner CRD instead of the CAPI
`clusters.cluster.x-k8s.io`. This caused the deployment monitor to report the
workload cluster as "not found" and stall the run, even though the cluster was
provisioning correctly.

This qualifies all CAPI Cluster get/delete queries with the fully-qualified
resource name so they are unambiguous regardless of other installed CRDs.

JIRA: https://redhat.atlassian.net/browse/ARO-29248

## Changes Made

- `scripts/monitor-cluster-json.sh` — qualify the live 30s-polled monitor query (the reported blocker)
- `test/helpers.go` — add a `capiClusterResource` constant and use it in `RequireClusterResource`, `GetDeletionResourceStatus`, `GetExistingClusterNames`, and the `FormatMismatchedClustersError` cleanup-guidance messages
- `test/05_deploy_crs_test.go` — qualify the `MonitorCluster` existence probe and troubleshooting hint messages
- `test/07_deletion_test.go` — qualify the existence check and the `delete` itself (same collision affects deletion), plus hint messages
- `test/helpers_test.go` — update `TestFormatMismatchedClustersError` assertions to expect the qualified resource name

## Configuration Changes

None.

## Additional Notes

- Verified with `go build ./...`, `go vet ./test/...`, and `gofmt` (all clean).
- `clusterctl describe cluster`, `kind get clusters`, and plain-English log/comment text were intentionally left unchanged — they are not ambiguous kubectl queries.
- Follow-up candidates (out of scope, not blocking): the cosmetic error label in `scripts/monitor-cluster-json.sh` (`"kubectl get cluster failed"`) and the `docs/test-analysis/*` command references still say bare `cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)