### PR TITLE
fix: rewrite Kind-internal kubeconfig server for null-provisioning

### DIFF
--- a/scripts/monitor-cluster-json.sh
+++ b/scripts/monitor-cluster-json.sh
@@ -324,7 +324,20 @@ NODES_ERROR=""
 if "${KUBECTL_CMD[@]}" get secret "$KUBECONFIG_SECRET" -n "$NAMESPACE" &>/dev/null; then
     # Try to get nodes, capturing both stdout and stderr
     # Note: Use plain 'kubectl' without context since we're using the workload cluster's kubeconfig via stdin
-    NODES_RESULT=$("${KUBECTL_CMD[@]}" get secret "$KUBECONFIG_SECRET" -n "$NAMESPACE" -o jsonpath='{.data.value}' 2>/dev/null | base64 -d | \
+    WORKLOAD_KUBECONFIG=$("${KUBECTL_CMD[@]}" get secret "$KUBECONFIG_SECRET" -n "$NAMESPACE" -o jsonpath='{.data.value}' 2>/dev/null | base64 -d)
+    # In null-provisioning mode the kubeconfig has Docker-internal DNS names
+    # (e.g. cluster-control-plane:6443) that are only resolvable inside the Kind
+    # network. Rewrite to the host-accessible 127.0.0.1:<port> via kind.
+    if [[ "${ARO_NULL_PROVISIONING:-}" == "true" ]]; then
+        KIND_CLUSTER=$(echo "$WORKLOAD_KUBECONFIG" | grep -oP '(?<=https://)[a-zA-Z0-9_-]+(?=-control-plane:6443)' || true)
+        if [[ -n "$KIND_CLUSTER" ]]; then
+            HOST_SERVER=$(kind get kubeconfig --name "$KIND_CLUSTER" 2>/dev/null | grep -oP 'https://127\.0\.0\.1:\d+' | head -1 || true)
+            if [[ -n "$HOST_SERVER" ]]; then
+                WORKLOAD_KUBECONFIG=$(echo "$WORKLOAD_KUBECONFIG" | sed "s|https://${KIND_CLUSTER}-control-plane:6443|${HOST_SERVER}|g")
+            fi
+        fi
+    fi
+    NODES_RESULT=$(echo "$WORKLOAD_KUBECONFIG" | \
         KUBECONFIG=/dev/stdin kubectl get nodes -o json 2>&1)
     NODES_EXIT_CODE=$?
 

--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -132,6 +133,8 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 			t.Errorf("Decoded kubeconfig is empty")
 			return
 		}
+
+		decoded = rewriteKindInternalServer(t, decoded)
 
 		if err := os.WriteFile(kubeconfigPath, decoded, 0600); err != nil {
 			t.Errorf("Failed to write kubeconfig to file: %v", err)
@@ -454,4 +457,40 @@ func TestVerification_ControllerLogSummary(t *testing.T) {
 	}
 
 	t.Logf("Controller logs saved to: %s", resultsDir)
+}
+
+// rewriteKindInternalServer detects Docker-internal Kind server addresses in a kubeconfig
+// and replaces them with host-accessible addresses. Kind containers use DNS names like
+// "cluster-name-control-plane:6443" which are only resolvable inside the Docker network.
+// When tests run on the host, they need "127.0.0.1:<port>" instead.
+func rewriteKindInternalServer(t *testing.T, kubeconfig []byte) []byte {
+	if os.Getenv("ARO_NULL_PROVISIONING") != "true" {
+		return kubeconfig
+	}
+
+	re := regexp.MustCompile(`https://([a-zA-Z0-9_-]+)-control-plane:6443`)
+	match := re.FindStringSubmatch(string(kubeconfig))
+	if match == nil {
+		return kubeconfig
+	}
+
+	kindClusterName := match[1]
+	t.Logf("Detected Kind-internal server address for cluster %q, rewriting for host access", kindClusterName)
+
+	hostKubeconfig, err := RunCommandQuiet(t, "kind", "get", "kubeconfig", "--name", kindClusterName)
+	if err != nil {
+		t.Logf("Warning: could not get Kind kubeconfig for %q: %v (keeping Docker-internal address)", kindClusterName, err)
+		return kubeconfig
+	}
+
+	hostRe := regexp.MustCompile(`https://127\.0\.0\.1:\d+`)
+	hostMatch := hostRe.FindString(hostKubeconfig)
+	if hostMatch == "" {
+		t.Logf("Warning: could not find host server address in Kind kubeconfig for %q", kindClusterName)
+		return kubeconfig
+	}
+
+	result := re.ReplaceAllString(string(kubeconfig), hostMatch)
+	t.Logf("Rewrote kubeconfig server: %s -> %s", match[0], hostMatch)
+	return []byte(result)
 }


### PR DESCRIPTION
## Summary
- In null-provisioning mode (`ARO_NULL_PROVISIONING=true`), the workload cluster kubeconfig stored in the k8s secret contains Docker-internal DNS names (e.g. `cluster-control-plane:6443`) set by `deploy-charts.sh` for in-cluster communication
- When tests run on the host, these DNS names are not resolvable, causing `kubectl get nodes` and cluster connectivity checks to fail
- Adds `rewriteKindInternalServer()` in `TestVerification_RetrieveKubeconfig` to detect the pattern and replace with `127.0.0.1:<port>` from `kind get kubeconfig`
- Adds the same rewrite in `monitor-cluster-json.sh` which reads the kubeconfig directly from the secret
- Both rewrites are gated on `ARO_NULL_PROVISIONING=true` — no-op for real clusters

## Test plan
- [x] Verified with `test0.sh aro` — deployment tests pass, kubeconfig is correctly rewritten
- [ ] Verify `TestVerification_ClusterNodes` can connect to the workload Kind cluster from the host
- [ ] Verify no impact on real cluster (non-null-provisioning) runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)