### PR TITLE
fix: avoid USE_K8S environment mutation (ARO-24273)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,7 +389,7 @@ export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
   - Skips repository cloning (Phase 02) when controllers are pre-installed
   - Validates pre-installed CAPI/CAPZ/ASO controllers
   - Uses the `current-context` from the specified kubeconfig file
-  - Automatically sets `USE_K8S=true` for MCE namespace defaults (`multicluster-engine`)
+  - Uses MCE namespace defaults (`multicluster-engine`) when charts are not deployed; this state is derived in `TestConfig` without modifying the process environment
 - `DEPLOY_CHARTS` - Deploy Helm charts to external cluster (default: `false`). When set to `true` with `USE_KUBECONFIG`:
   - Enables chart deployment to the external cluster (Phase 03)
   - Runs deploy-charts.sh with `DO_INIT_KIND=false` (skips Kind creation)

--- a/docs/API_REVIEW.md
+++ b/docs/API_REVIEW.md
@@ -117,7 +117,7 @@ This document provides a comprehensive review of all public interfaces. These co
 |----------|---------------|--------|-------|
 | `CAPI_NAMESPACE` | ✅ Approved | Good | Clear controller namespace override |
 | `CAPZ_NAMESPACE` | ✅ Approved | Good | Consistent with CAPI_NAMESPACE |
-| `USE_K8S` | ⚠️ Warning | Acceptable | Auto-set when `USE_KUBECONFIG` is provided; naming kept for backward compatibility |
+| `USE_K8S` | ⚠️ Warning | Acceptable | Explicitly enables MCE namespace selection; equivalent config state is derived when `USE_KUBECONFIG` is provided and charts are not deployed |
 | `ASO_CONTROLLER_TIMEOUT` | ✅ Approved | Good | Clear purpose, follows DEPLOYMENT_TIMEOUT pattern |
 
 ### Path Configuration Variables (Internal)
@@ -133,7 +133,7 @@ This document provides a comprehensive review of all public interfaces. These co
 
 1. **CS_CLUSTER_NAME**: ✅ Documented as **C**luster **S**ervice in CLAUDE.md (resolved in v1).
 
-2. **USE_K8S**: Now auto-set when `USE_KUBECONFIG` is provided. Naming kept for backward compatibility. Low priority to rename.
+2. **USE_K8S**: Naming is kept for backward compatibility. When `USE_KUBECONFIG` is provided and charts are not deployed, the equivalent state is derived in `TestConfig` without mutating the environment.
 
 3. **GEN_SCRIPT_PATH**: Abbreviation kept for backward compatibility. Low priority to rename.
 
@@ -388,7 +388,7 @@ Exit codes are consistent and follow Unix conventions.
 ### Deferred (Low Priority)
 
 6. **GEN_SCRIPT_PATH**: Abbreviation kept for backward compatibility
-7. **USE_K8S**: Naming kept for backward compatibility; now auto-set when `USE_KUBECONFIG` is provided
+7. **USE_K8S**: Naming kept for backward compatibility; the equivalent mode is derived in `TestConfig` when `USE_KUBECONFIG` is provided and charts are not deployed
 
 ---
 

--- a/docs/SECURITY_REVIEW.md
+++ b/docs/SECURITY_REVIEW.md
@@ -49,26 +49,27 @@ func ExtractCurrentContext(kubeconfigPath string) string {
 
 **Risk assessment**: Low. The path comes from an environment variable set by the test operator (who already has full shell access). There is no privilege escalation vector.
 
-#### 2. os.Setenv Side Effect in NewTestConfig()
+#### 2. Derived K8S Mode in NewTestConfig()
 
-**Status**: PASSED (acceptable trade-off)
+**Status**: PASSED
 
-**Location**: `test/config.go:164`
+**Location**: `test/config.go:645-652`
 
-**Analysis**: When `USE_KUBECONFIG` is set and `USE_K8S` is not, `NewTestConfig()` sets `USE_K8S=true` to default controller namespaces to `multicluster-engine`:
+**Analysis**: When `USE_KUBECONFIG` is set, `DEPLOY_CHARTS=false`, and `USE_K8S` is not set, `NewTestConfig()` derives `UseK8S=true` to default controller namespaces to `multicluster-engine`:
 
 ```go
-if useKubeconfig != "" && os.Getenv("USE_K8S") == "" {
-    _ = os.Setenv("USE_K8S", "true")
+useK8S := os.Getenv("USE_K8S") == "true"
+if useKubeconfig != "" && !deployCharts && os.Getenv("USE_K8S") == "" {
+    useK8S = true
 }
 ```
 
 **Security implications**:
-- Mutates global process state, which could affect other code reading `USE_K8S`
-- The `#nosec G104` suppression for the ignored error return is justified: `os.Setenv` with a fixed key and value cannot fail in any realistic scenario (it would only fail if the OS kernel rejected the syscall)
-- The side effect is documented in CLAUDE.md and the code comment
+- Does not mutate global process state, preventing constructor calls from affecting unrelated code reading `USE_K8S`
+- The derived state is stored on `TestConfig` and used by namespace resolution and readiness checks
+- An explicit `USE_K8S` value remains supported for backward compatibility
 
-**Risk assessment**: Low. This is a test framework configuration convenience, not a security boundary. The mutation is idempotent and deterministic.
+**Risk assessment**: Low. This is a test framework configuration convenience, not a security boundary, and it no longer changes the caller's environment.
 
 #### 3. SetMCEComponentState() / EnableMCEComponent() - jq Command Injection
 
@@ -170,19 +171,18 @@ if data, err := os.ReadFile(stateFilePath); err == nil {
 
 ### V1.1 #nosec Annotation Audit
 
-All 7 current `#nosec` annotations were reviewed and verified as justified:
+All 6 current `#nosec` annotations were reviewed and verified as justified:
 
 | # | Location | Rule | Justification | Verdict |
 |---|----------|------|---------------|---------|
 | 1 | `config.go:91` | G304 | Path from repo dir + fixed filename `.deployment-state.json` | Justified |
-| 2 | `config.go:164` | G104 | `os.Setenv("USE_K8S", "true")` cannot fail in practice | Justified |
-| 3 | `helpers.go:414` | G304 | `ExtractClusterNameFromYAML` - path from test config | Justified |
-| 4 | `helpers.go:1494` | G304 | `ValidateYAMLFile` - path validated via `os.Stat`, from test config | Justified |
-| 5 | `helpers.go:1517` | G304 | `ExtractNamespaceFromYAML` - path from test config | Justified |
-| 6 | `helpers.go:2795` | G204 | `SetMCEComponentState` - jq with compile-time constant component names | Justified |
-| 7 | `helpers.go:2844` | G204 | `EnableMCEComponent` - jq with compile-time constant component names | Justified |
+| 2 | `helpers.go:414` | G304 | `ExtractClusterNameFromYAML` - path from test config | Justified |
+| 3 | `helpers.go:1494` | G304 | `ValidateYAMLFile` - path validated via `os.Stat`, from test config | Justified |
+| 4 | `helpers.go:1517` | G304 | `ExtractNamespaceFromYAML` - path from test config | Justified |
+| 5 | `helpers.go:2795` | G204 | `SetMCEComponentState` - jq with compile-time constant component names | Justified |
+| 6 | `helpers.go:2844` | G204 | `EnableMCEComponent` - jq with compile-time constant component names | Justified |
 
-**Change from V1**: Annotations #1 and #2 are new in v1.1 (config.go). Annotation #5 (`ExtractNamespaceFromYAML`) is also new. The total increased from 5 to 7, all properly documented with inline justifications.
+**Change from V1**: Annotation #1 is new in v1.1 (config.go). Annotation #4 (`ExtractNamespaceFromYAML`) is also new. The total increased from 5 to 6, all properly documented with inline justifications.
 
 ### V1.1 Security Scan Results
 

--- a/docs/analysis/433-external-kubeconfig-support.md
+++ b/docs/analysis/433-external-kubeconfig-support.md
@@ -66,8 +66,8 @@ This pattern appears in 50+ locations across test files.
 - User sets context before running: `kubectl config use-context <name>`
 
 **Namespace Configuration:**
-- External clusters use `multicluster-engine` namespace (MCE installation)
-- Leverages existing `USE_K8S=true` pattern for namespace resolution
+- External clusters use `multicluster-engine` namespace (MCE installation) when charts are not deployed
+- `TestConfig.UseK8S` derives this mode without modifying the `USE_K8S` environment variable
 
 ### Implementation Details
 
@@ -83,19 +83,24 @@ type TestConfig struct {
     // - Validates pre-installed controllers
     // - Uses current-context from the kubeconfig
     UseKubeconfig string
+
+    // UseK8S selects multicluster-engine namespaces for controller checks.
+    UseK8S bool
 }
 
 func NewTestConfig() *TestConfig {
     useKubeconfig := os.Getenv("USE_KUBECONFIG")
 
-    // When using external kubeconfig, default to MCE namespaces
-    if useKubeconfig != "" {
-        os.Setenv("USE_K8S", "true")  // Triggers multicluster-engine namespaces
+    // Derive MCE namespace selection without mutating the caller environment.
+    useK8S := os.Getenv("USE_K8S") == "true"
+    if useKubeconfig != "" && !deployCharts && os.Getenv("USE_K8S") == "" {
+        useK8S = true
     }
 
     return &TestConfig{
         // ...existing initialization...
         UseKubeconfig: useKubeconfig,
+        UseK8S: useK8S,
     }
 }
 

--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -752,7 +752,7 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 				t.Log("CAPI controller manager deployment is available")
 
 				// Also check mce-capi-webhook-config when not in Kind/K8S mode
-				if os.Getenv("USE_KIND") != "true" && os.Getenv("USE_K8S") != "true" {
+				if !config.UseKind && !config.UseK8S {
 					PrintToTTY("Checking mce-capi-webhook-config deployment...\n")
 					mceOutput, mceErr := RunCommand(t, "kubectl", "--context", context, "-n", config.CAPINamespace,
 						"get", "deployment", "mce-capi-webhook-config",
@@ -899,7 +899,7 @@ func TestKindCluster_WebhooksReady(t *testing.T) {
 	webhooks := config.AllWebhooks()
 
 	// MCE webhook is only available in full MCE deployment, not in Kind/K8S mode
-	if os.Getenv("USE_KIND") != "true" && os.Getenv("USE_K8S") != "true" {
+	if !config.UseKind && !config.UseK8S {
 		webhooks = append(webhooks, WebhookDef{
 			DisplayName: "MCE",
 			Namespace:   config.CAPINamespace,

--- a/test/config.go
+++ b/test/config.go
@@ -486,8 +486,8 @@ type TestConfig struct {
 	TestRunID                string            // Unique run identifier extracted from ClusterNamePrefix (the part after CAPI_USER-). Empty when prefix does not start with CAPI_USER-.
 	ResourceTags             map[string]string // Tags applied to all created cloud resources (Azure RGs, AWS stacks/VPCs) for ownership tracking and cleanup
 	ResourceGroupName        string            // Azure resource group name (env: RESOURCEGROUPNAME, default: ${WorkloadClusterName}-${runID}-resgroup)
-	CAPINamespace            string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" when USE_K8S=true)
-	CAPZNamespace            string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" when USE_K8S=true)
+	CAPINamespace            string            // Namespace for CAPI controller (default: "capi-system", or "multicluster-engine" in K8S mode)
+	CAPZNamespace            string            // Namespace for CAPZ/ASO controllers (default: "capz-system", or "multicluster-engine" in K8S mode)
 
 	// Management cluster mode
 	// ClusterMode specifies the management cluster deployment mode ("kind" or "mce").
@@ -507,6 +507,11 @@ type TestConfig struct {
 	// UseKind enables Kind deployment mode (USE_KIND=true).
 	// When true, creates a local Kind management cluster with CAPI/CAPZ/ASO controllers.
 	UseKind bool
+
+	// UseK8S selects the multicluster-engine namespace for all controllers.
+	// It is enabled explicitly with USE_K8S=true or implicitly for an external
+	// kubeconfig when chart deployment is disabled.
+	UseK8S bool
 
 	// Paths
 	ClusterctlBinPath string
@@ -639,11 +644,12 @@ func NewTestConfig() *TestConfig {
 		}
 	}
 
-	// When using external kubeconfig WITHOUT deploying charts, default to MCE namespaces (USE_K8S=true)
-	// This triggers multicluster-engine namespace for all controllers.
-	// When DEPLOY_CHARTS=true, we're deploying to standard namespaces (capi-system, capz-system).
+	// An external kubeconfig without chart deployment uses the namespaces where
+	// MCE provides the controllers. Keep this derived state in the config rather
+	// than mutating USE_K8S in the caller's environment.
+	useK8S := os.Getenv("USE_K8S") == "true"
 	if useKubeconfig != "" && !deployCharts && os.Getenv("USE_K8S") == "" {
-		_ = os.Setenv("USE_K8S", "true") // #nosec G104 - os.Setenv with fixed key/value cannot fail in practice
+		useK8S = true
 	}
 
 	// Determine infrastructure provider
@@ -666,7 +672,7 @@ func NewTestConfig() *TestConfig {
 
 	switch infraProviderName {
 	case "rosa":
-		providerNamespace = getControllerNamespace("CAPA_NAMESPACE", "capa-system")
+		providerNamespace = getControllerNamespace(useK8S, "CAPA_NAMESPACE", "capa-system")
 		infraProviders = []InfraProvider{NewAWSProvider(providerNamespace)}
 		defaultGenScriptPath = "./scripts/rosa-hcp/gen.sh"
 		defaultMgmtCluster = "capa-tests-stage"
@@ -677,7 +683,7 @@ func NewTestConfig() *TestConfig {
 		defaultRegion = "us-east-1"
 	default: // "aro"
 		infraProviderName = "aro" // normalize unknown values
-		providerNamespace = getControllerNamespace("CAPZ_NAMESPACE", "capz-system")
+		providerNamespace = getControllerNamespace(useK8S, "CAPZ_NAMESPACE", "capz-system")
 		azureProvider := NewAzureProvider(providerNamespace)
 		for i := range azureProvider.Controllers {
 			if azureProvider.Controllers[i].DisplayName == "ASO" {
@@ -747,7 +753,7 @@ func NewTestConfig() *TestConfig {
 		TestRunID:                testRunID,
 		ResourceTags:             resourceTags,
 		ResourceGroupName:        rgName,
-		CAPINamespace:            getControllerNamespace("CAPI_NAMESPACE", "capi-system"),
+		CAPINamespace:            getControllerNamespace(useK8S, "CAPI_NAMESPACE", "capi-system"),
 		CAPZNamespace:            providerNamespace,
 
 		// Management cluster mode
@@ -758,6 +764,7 @@ func NewTestConfig() *TestConfig {
 
 		// Kind mode
 		UseKind: os.Getenv("USE_KIND") == "true",
+		UseK8S:  useK8S,
 
 		// Paths
 		ClusterctlBinPath: GetEnvOrDefault("CLUSTERCTL_BIN", "./bin/clusterctl"),
@@ -788,11 +795,11 @@ func NewTestConfig() *TestConfig {
 }
 
 // getControllerNamespace returns the namespace for a controller based on configuration.
-// If USE_K8S=true, returns "multicluster-engine" (K8S deployment mode).
+// If useK8S is true, returns "multicluster-engine" (K8S deployment mode).
 // Otherwise, checks the specific env var (e.g., CAPI_NAMESPACE) and falls back to defaultNS.
-func getControllerNamespace(envVar, defaultNS string) string {
-	// Check if USE_K8S mode is enabled - all controllers use multicluster-engine namespace
-	if os.Getenv("USE_K8S") == "true" {
+func getControllerNamespace(useK8S bool, envVar, defaultNS string) string {
+	// K8S mode uses the multicluster-engine namespace for all controllers.
+	if useK8S {
 		return "multicluster-engine"
 	}
 

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -78,6 +78,38 @@ func TestGetDefaultRepoDir_PathFormat(t *testing.T) {
 	t.Logf("Path format validated: %s", config.RepoDir)
 }
 
+func TestNewTestConfig_ExternalKubeconfigUsesMCENamespacesWithoutMutatingUseK8S(t *testing.T) {
+	t.Setenv("USE_KUBECONFIG", "/tmp/external-kubeconfig")
+	t.Setenv("DEPLOY_CHARTS", "false")
+
+	originalUseK8S, useK8SWasSet := os.LookupEnv("USE_K8S")
+	if err := os.Unsetenv("USE_K8S"); err != nil {
+		t.Fatalf("Unsetenv(USE_K8S): %v", err)
+	}
+	t.Cleanup(func() {
+		if useK8SWasSet {
+			_ = os.Setenv("USE_K8S", originalUseK8S)
+			return
+		}
+		_ = os.Unsetenv("USE_K8S")
+	})
+
+	config := NewTestConfig()
+
+	if !config.UseK8S {
+		t.Error("UseK8S = false, want true for an external kubeconfig without chart deployment")
+	}
+	if config.CAPINamespace != "multicluster-engine" {
+		t.Errorf("CAPI namespace = %q, want multicluster-engine", config.CAPINamespace)
+	}
+	if config.CAPZNamespace != "multicluster-engine" {
+		t.Errorf("CAPZ namespace = %q, want multicluster-engine", config.CAPZNamespace)
+	}
+	if _, isSet := os.LookupEnv("USE_K8S"); isSet {
+		t.Error("NewTestConfig() set USE_K8S, want it to remain unset")
+	}
+}
+
 func TestParseDeploymentTimeout_Default(t *testing.T) {
 	// Ensure DEPLOYMENT_TIMEOUT is not set
 	originalValue := os.Getenv("DEPLOYMENT_TIMEOUT")


### PR DESCRIPTION
## Summary

Refactors external-cluster K8S mode selection so NewTestConfig no longer mutates the caller's USE_K8S environment variable.

Jira: https://redhat.atlassian.net/browse/ARO-24273

## Problem

When USE_KUBECONFIG was set and charts were not deployed, NewTestConfig called os.Setenv for USE_K8S. This surprising constructor side effect could affect unrelated code in the same process.

## Solution

Derive the effective K8S mode on TestConfig.UseK8S and consume it directly for namespace selection and readiness checks.

## Changes

- Preserve external-cluster MCE namespace defaults without mutating USE_K8S
- Update readiness checks to use explicit configuration state
- Add a regression test that proves USE_K8S stays unset
- Correct documentation and security/API review records

## Testing

- [x] Focused configuration tests passed
- [x] go vet passed
- [x] make fmt passed
- [x] make test passed

Ref: ARO-24273

Generated with Codex