### PR TITLE
fix: stop deployment monitor tests after failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,7 +249,7 @@ _deploy-crs: check-gotestsum
 	if [ $$EXIT_CODE -eq 0 ]; then \
 		echo ""; \
 		echo "--- Phase 2: Monitor deployment ---"; \
-		CLUSTER_DEPLOYMENT_TIMEOUT=$(CLUSTER_DEPLOYMENT_TIMEOUT) TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) || EXIT_CODE=$$?; \
+		CLUSTER_DEPLOYMENT_TIMEOUT=$(CLUSTER_DEPLOYMENT_TIMEOUT) TEST_RESULTS_DIR=$(TEST_RESULTS_DIR) $(GOTESTSUM) --junitfile=$(RESULTS_DIR)/junit-deploy-monitor.xml -- $(TEST_VERBOSITY) ./test -count=1 -run "TestDeployment_Monitor|TestDeployment_Wait|TestDeployment_Verify|TestDeployment_Tag" -timeout $(GO_STEP_DEPLOY_CRS_TIMEOUT) -failfast || EXIT_CODE=$$?; \
 	fi; \
 	mkdir -p $(LATEST_RESULTS_DIR); \
 	cp -f $(RESULTS_DIR)/*.xml $(LATEST_RESULTS_DIR)/ 2>/dev/null || true; \


### PR DESCRIPTION
## Description

Stop dependent deployment tests after `TestDeployment_WaitForControlPlane` fails, preventing unnecessary readiness waits and follow-on failures.

Fixes ARO-29467

## Changes Made

- Add Go `-failfast` to the CR deployment monitor test invocation.
- Keep the existing apply-phase fail-fast behavior unchanged.

## Configuration Changes

No configuration changes.

## Additional Notes

`git diff --check` and `make -n _deploy-crs` passed. `make test` ran but reports environment failures because Docker is unavailable and Azure authentication/subscription variables are not configured.
