### PR TITLE
Improve authentication and credential failure diagnostics

### DIFF
--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -250,6 +250,9 @@ func TestCheckDependencies_ExternalKubeconfig(t *testing.T) {
 	SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
 	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes", "--no-headers")
 	if err != nil {
+		if authErr := DetectKubeconfigAuthError(output + " " + err.Error()); authErr != nil {
+			t.Fatalf("Cannot authenticate to external cluster with context '%s': %v\n%s", context, err, FormatKubeconfigAuthError(authErr))
+		}
 		t.Fatalf("Cannot connect to external cluster with context '%s': %v\n\nEnsure the cluster is accessible and credentials are valid.", context, err)
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2606,6 +2606,89 @@ func FormatNetworkError(info *NetworkErrorInfo) string {
 	return result.String()
 }
 
+// KubeconfigAuthErrorInfo contains structured diagnostics for authentication
+// and authorization failures returned while using a kubeconfig.
+type KubeconfigAuthErrorInfo struct {
+	ErrorType   string   // Short error type identifier.
+	Message     string   // Human-readable error description.
+	Remediation []string // Steps to restore access.
+}
+
+// DetectKubeconfigAuthError analyzes kubectl or oc output for authentication
+// and authorization failures. It deliberately does not classify connectivity
+// errors, which are handled by DetectNetworkError.
+func DetectKubeconfigAuthError(output string) *KubeconfigAuthErrorInfo {
+	lowerOutput := strings.ToLower(output)
+
+	// Expired tokens and client certificates require refreshing the credentials
+	// in the kubeconfig rather than changing Kubernetes RBAC.
+	if strings.Contains(lowerOutput, "token has expired") ||
+		strings.Contains(lowerOutput, "token is expired") ||
+		strings.Contains(lowerOutput, "certificate has expired") ||
+		(strings.Contains(lowerOutput, "client certificate") && strings.Contains(lowerOutput, "expired")) {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "credentials_expired",
+			Message:   "The kubeconfig credentials have expired",
+			Remediation: []string{
+				"Refresh or regenerate the token or client certificate used by the kubeconfig",
+				"For an OpenShift cluster, authenticate again with: oc login <api-url>",
+				"For a managed cluster, retrieve a new kubeconfig from the cluster provider",
+				"Verify the system clock is correct if a valid certificate is reported as expired",
+			},
+		}
+	}
+
+	// Forbidden responses indicate a valid identity with insufficient RBAC.
+	if strings.Contains(lowerOutput, "forbidden") ||
+		(strings.Contains(lowerOutput, "cannot ") && strings.Contains(lowerOutput, " resource")) {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "insufficient_permissions",
+			Message:   "The authenticated identity is not authorized to perform the requested Kubernetes operation",
+			Remediation: []string{
+				"Identify the kubeconfig user or service account: kubectl config view --minify",
+				"Ask a cluster administrator to grant the required Kubernetes RBAC role or role binding",
+				"Confirm the kubeconfig context points to the intended cluster and namespace",
+			},
+		}
+	}
+
+	// Unauthorized responses indicate missing, invalid, or rejected credentials.
+	if strings.Contains(lowerOutput, "unauthorized") ||
+		strings.Contains(lowerOutput, "authentication required") ||
+		strings.Contains(lowerOutput, "invalid bearer token") ||
+		strings.Contains(lowerOutput, "provide credentials") {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "authentication_failed",
+			Message:   "The kubeconfig credentials were rejected by the Kubernetes API server",
+			Remediation: []string{
+				"Verify the kubeconfig user, token, or client certificate is valid",
+				"Refresh the credentials or retrieve a new kubeconfig from the cluster provider",
+				"Confirm the kubeconfig context points to the intended cluster",
+			},
+		}
+	}
+
+	return nil
+}
+
+// FormatKubeconfigAuthError formats kubeconfig authentication diagnostics for
+// display in dependency and external-cluster validation failures.
+func FormatKubeconfigAuthError(info *KubeconfigAuthErrorInfo) string {
+	if info == nil {
+		return ""
+	}
+
+	var result strings.Builder
+	fmt.Fprintf(&result, "\n=== Kubeconfig Authentication Error: %s ===\n", info.Message)
+	result.WriteString("\nRemediation steps:\n")
+	for _, step := range info.Remediation {
+		fmt.Fprintf(&result, "  %s\n", step)
+	}
+	result.WriteString("\n")
+
+	return result.String()
+}
+
 // RequireClusterResource skips the test if the CAPI Cluster resource does not exist or is in a Failed phase.
 // Use this at the top of verification tests that depend on earlier deployment phases succeeding.
 func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -3170,6 +3170,80 @@ func TestFormatNetworkError(t *testing.T) {
 	}
 }
 
+func TestDetectKubeconfigAuthError(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		expectedType string
+		expectNil    bool
+	}{
+		{
+			name:         "expired bearer token",
+			output:       "error: You must be logged in to the server (the provided bearer token has expired)",
+			expectedType: "credentials_expired",
+		},
+		{
+			name:         "expired client certificate",
+			output:       "tls: failed to verify certificate: x509: certificate has expired or is not yet valid",
+			expectedType: "credentials_expired",
+		},
+		{
+			name:         "unauthorized",
+			output:       "Error from server (Unauthorized): the server has asked for the client to provide credentials",
+			expectedType: "authentication_failed",
+		},
+		{
+			name:         "forbidden",
+			output:       "Error from server (Forbidden): pods is forbidden: User cannot list resource pods",
+			expectedType: "insufficient_permissions",
+		},
+		{
+			name:      "unrelated kubectl error",
+			output:    "The connection to the server was refused",
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DetectKubeconfigAuthError(tc.output)
+			if tc.expectNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %q", result.ErrorType)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected authentication error, got nil")
+			}
+			if result.ErrorType != tc.expectedType {
+				t.Errorf("error type = %q, expected %q", result.ErrorType, tc.expectedType)
+			}
+			if result.Message == "" || len(result.Remediation) == 0 {
+				t.Error("expected message and remediation steps")
+			}
+		})
+	}
+}
+
+func TestFormatKubeconfigAuthError(t *testing.T) {
+	if got := FormatKubeconfigAuthError(nil); got != "" {
+		t.Fatalf("FormatKubeconfigAuthError(nil) = %q, expected empty string", got)
+	}
+
+	info := &KubeconfigAuthErrorInfo{
+		ErrorType:   "insufficient_permissions",
+		Message:     "The authenticated identity is not authorized to perform the requested Kubernetes operation",
+		Remediation: []string{"Grant the required RBAC role to the kubeconfig identity"},
+	}
+	formatted := FormatKubeconfigAuthError(info)
+	for _, expected := range []string{"Kubeconfig Authentication Error", info.Message, "Remediation steps:", info.Remediation[0]} {
+		if !strings.Contains(formatted, expected) {
+			t.Errorf("formatted error does not contain %q: %s", expected, formatted)
+		}
+	}
+}
+
 // TestHasServicePrincipalCredentials tests the HasServicePrincipalCredentials function.
 func TestHasServicePrincipalCredentials(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Improve actionable diagnostics for authentication and credential failures in external kubeconfig validation.

Jira: ARO-24302

## Changes Made

- Add structured detection for expired kubeconfig credentials, rejected authentication, and insufficient Kubernetes permissions.
- Integrate authentication diagnostics into external-cluster dependency validation.
- Add focused table-driven unit tests and remediation guidance.

## Configuration Changes

No configuration changes.

## Additional Notes

Focused authentication/error-classification tests pass, and the `go vet` fallback from `make lint` passes. The full integration suite was attempted but could not complete in this local environment because the configured `crc-admin` Kubernetes context is unavailable.