### PR TITLE
feat: report security findings to Jira

### DIFF
--- a/.github/workflows/security-gosec.yml
+++ b/.github/workflows/security-gosec.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "**" ]
   schedule:
-    # Run daily at 2:30 AM UTC
     - cron: '30 2 * * *'
   workflow_dispatch:
 
@@ -21,7 +20,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      issues: write
 
     steps:
     - name: Checkout code
@@ -43,35 +41,13 @@ jobs:
     - name: Generate summary
       if: always()
       run: |
-        echo "# gosec Security Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
+        echo "# gosec Security Scan Results" >> "$GITHUB_STEP_SUMMARY"
         if [ -f gosec-results.json ]; then
-          # Parse JSON results
           ISSUES=$(jq -r '.Issues // [] | length' gosec-results.json 2>/dev/null || echo "0")
-
-          if [ "$ISSUES" = "0" ]; then
-            echo "## ✅ No security issues found!" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Go source code passed all gosec security checks." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "## ❌ Security issues detected: $ISSUES" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Issues Found" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Severity | Rule | File | Line | Details |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|------|------|------|---------|" >> $GITHUB_STEP_SUMMARY
-
-            jq -r '.Issues[] | "| \(.severity) | \(.rule_id) | \(.file) | \(.line) | \(.details) |"' gosec-results.json >> $GITHUB_STEP_SUMMARY 2>/dev/null || true
-
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Recommendations" >> $GITHUB_STEP_SUMMARY
-            echo "1. Review each security issue listed above" >> $GITHUB_STEP_SUMMARY
-            echo "2. Apply recommended fixes from gosec documentation" >> $GITHUB_STEP_SUMMARY
-            echo "3. Re-run the scan to verify fixes" >> $GITHUB_STEP_SUMMARY
-          fi
+          echo "Detected issues: $ISSUES" >> "$GITHUB_STEP_SUMMARY"
+          jq -r '.Issues[] | "- \(.severity): \(.rule_id) - \(.file):\(.line) - \(.details)"' gosec-results.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
         else
-          echo "⚠️ No results file generated" >> $GITHUB_STEP_SUMMARY
+          echo "No results file generated" >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Upload gosec results
@@ -82,162 +58,40 @@ jobs:
         path: gosec-results.json
         retention-days: 30
 
-    - name: Create GitHub issue on security findings
+    - name: Report security findings to Jira
       if: steps.gosec-scan.outcome == 'failure' && github.event_name != 'pull_request'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_PARENT_KEY: ${{ vars.JIRA_SECURITY_PARENT_KEY }}
+        JIRA_ASSIGNEE_ACCOUNT_ID: ${{ vars.JIRA_ASSIGNEE_ACCOUNT_ID }}
         SERVER_URL: ${{ github.server_url }}
         REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
         REF_NAME: ${{ github.ref_name }}
         SHA: ${{ github.sha }}
       run: |
-        # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "gosec" --json number --jq ".[0].number" 2>/dev/null || echo "")
-
-        if [ -n "$EXISTING_ISSUE" ]; then
-          echo "Existing issue found: #$EXISTING_ISSUE"
-
-          # Count current issues
-          ISSUES=$(jq -r '.Issues // [] | length' gosec-results.json 2>/dev/null || echo "0")
-
-          # Build comment body using echo statements to avoid YAML heredoc issues
-          {
-            echo "## 🔄 Security Issues Still Present"
-            echo ""
-            echo "**New Detection**: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "**Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-            echo "**Branch**: ${REF_NAME}"
-            echo "**Commit**: ${SHA}"
-            echo "**Issues Count**: $ISSUES"
-            echo ""
-            echo "### Latest Findings"
-            echo ""
-            echo "<details>"
-            echo "<summary>Click to expand gosec findings</summary>"
-            echo ""
-            if [ -f gosec-results.json ] && [ "$ISSUES" != "0" ]; then
-              jq -r '.Issues[] | "**\(.severity)** - \(.rule_id) - `\(.file):\(.line)`\n\(.details)\n"' gosec-results.json 2>/dev/null | head -50
-            else
-              echo "See workflow logs for details"
-            fi
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "**Action Required**: Security issues persist. Please review and fix."
-          } > comment_body.md
-
-          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
-        else
-          echo "Creating new issue..."
-
-          # Parse issue details
-          ISSUES=$(jq -r '.Issues // [] | length' gosec-results.json 2>/dev/null || echo "0")
-          HIGH=$(jq -r '[.Issues[] | select(.severity == "HIGH")] | length' gosec-results.json 2>/dev/null || echo "0")
-          MEDIUM=$(jq -r '[.Issues[] | select(.severity == "MEDIUM")] | length' gosec-results.json 2>/dev/null || echo "0")
-          LOW=$(jq -r '[.Issues[] | select(.severity == "LOW")] | length' gosec-results.json 2>/dev/null || echo "0")
-
-          # Build issue body using echo statements to avoid YAML heredoc issues
-          {
-            echo "# 🚨 Security Alert: Code Security Issues Detected (gosec)"
-            echo ""
-            echo "## Overview"
-            echo ""
-            echo "The **gosec** source code security scanner has detected security issues in the Go codebase."
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Scanner** | gosec (Go AST security analyzer) |"
-            echo "| **Status** | ❌ FAILED |"
-            echo "| **Total Issues** | $ISSUES |"
-            echo "| **🔴 HIGH** | $HIGH |"
-            echo "| **🟡 MEDIUM** | $MEDIUM |"
-            echo "| **🟢 LOW** | $LOW |"
-            echo "| **Workflow Run** | [${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) |"
-            echo "| **Branch** | \`${REF_NAME}\` |"
-            echo "| **Commit** | \`${SHA}\` |"
-            echo "| **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |"
-            echo ""
-            echo "## 📋 Security Issues Found"
-            echo ""
-            echo "<details open>"
-            echo "<summary><b>Detailed Findings (Click to collapse)</b></summary>"
-            echo ""
-            if [ -f gosec-results.json ] && [ "$ISSUES" != "0" ]; then
-              echo "| Severity | Rule | File | Line | Details |"
-              echo "|----------|------|------|------|---------|"
-              jq -r '.Issues[] | "| \(.severity) | \(.rule_id) | `\(.file)` | \(.line) | \(.details) |"' gosec-results.json 2>/dev/null
-            else
-              echo "See workflow run logs for complete details"
-            fi
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "## 🔧 Remediation Steps"
-            echo ""
-            echo "### 1️⃣ Review Each Finding"
-            echo "- Examine the security issues listed above"
-            echo "- Understand the security risk for each"
-            echo "- Check gosec documentation for the specific rule ID"
-            echo ""
-            echo "### 2️⃣ Fix Security Issues"
-            echo ""
-            echo "Common fixes:"
-            echo "- **G104**: Add proper error handling"
-            echo "- **G304**: Validate file paths or add \`#nosec\` with justification"
-            echo "- **G401/G501**: Use stronger crypto algorithms"
-            echo "- **Others**: Follow gosec recommendations"
-            echo ""
-            echo "### 3️⃣ Suppress False Positives (If Appropriate)"
-            echo "\`\`\`go"
-            echo "// #nosec G304 - Justification for why this is safe"
-            echo "data, err := os.ReadFile(filePath)"
-            echo "\`\`\`"
-            echo ""
-            echo "### 4️⃣ Test Changes"
-            echo "\`\`\`bash"
-            echo "# Run tests"
-            echo "go test ./..."
-            echo ""
-            echo "# Run gosec locally"
-            echo "go install github.com/securego/gosec/v2/cmd/gosec@v2.25.0"
-            echo "gosec ./..."
-            echo "\`\`\`"
-            echo ""
-            echo "### 5️⃣ Verify Fix"
-            echo "- Push changes to a branch"
-            echo "- The gosec workflow will run automatically"
-            echo "- Verify it passes before merging"
-            echo ""
-            echo "## 📚 Resources"
-            echo ""
-            echo "- [gosec Documentation](https://github.com/securego/gosec)"
-            echo "- [Available Rules](https://github.com/securego/gosec#available-rules)"
-            echo "- [CWE Database](https://cwe.mitre.org/)"
-            echo "- [Workflow File](${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-gosec.yml)"
-            echo ""
-            echo "## 🔔 Next Steps"
-            echo ""
-            echo "1. **Triage** issues by severity (HIGH → MEDIUM → LOW)"
-            echo "2. **Fix** legitimate security issues"
-            echo "3. **Suppress** false positives with \`#nosec\` and justification"
-            echo "4. **Test** thoroughly to ensure no regressions"
-            echo "5. **Close** this issue once the workflow passes"
-            echo ""
-            echo "---"
-            echo ""
-            echo "*🤖 This issue was automatically created by the [gosec security workflow](${SERVER_URL}/${REPO}/actions/workflows/security-gosec.yml)*"
-          } > issue_body.md
-
-          # Create issue with security labels
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "🚨 [gosec] Security issues detected on ${REF_NAME}" \
-            --label "security" \
-            --label "gosec" \
-            --body-file issue_body.md || \
-          echo "Failed to create issue, but continuing workflow"
-        fi
+        ISSUES=$(jq -r '.Issues // [] | length' gosec-results.json 2>/dev/null || echo "0")
+        HIGH=$(jq -r '[.Issues[] | select(.severity == "HIGH")] | length' gosec-results.json 2>/dev/null || echo "0")
+        MEDIUM=$(jq -r '[.Issues[] | select(.severity == "MEDIUM")] | length' gosec-results.json 2>/dev/null || echo "0")
+        LOW=$(jq -r '[.Issues[] | select(.severity == "LOW")] | length' gosec-results.json 2>/dev/null || echo "0")
+        {
+          echo "Security Alert: Code Security Issues Detected (gosec)"
+          echo "Scanner: gosec"
+          echo "Status: FAILED"
+          echo "Total issues: $ISSUES (HIGH: $HIGH, MEDIUM: $MEDIUM, LOW: $LOW)"
+          echo "Workflow run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          echo "Branch: ${REF_NAME}"
+          echo "Commit: ${SHA}"
+          echo ""
+          jq -r '.Issues[] | "\(.severity) - \(.rule_id) - \(.file):\(.line)\n\(.details)\n"' gosec-results.json 2>/dev/null || true
+          echo "Remediation: review each finding, fix legitimate issues, and rerun gosec."
+          echo "Workflow: ${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-gosec.yml"
+        } > jira-report.md
+        ./scripts/report-security-finding.sh \
+          --scanner gosec \
+          --summary "[Security][gosec] Security findings detected" \
+          --body-file jira-report.md
 
     - name: Fail if security issues found
       if: steps.gosec-scan.outcome == 'failure'

--- a/.github/workflows/security-govulncheck.yml
+++ b/.github/workflows/security-govulncheck.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "**" ]
   schedule:
-    # Run daily at 2 AM UTC
     - cron: '0 2 * * *'
   workflow_dispatch:
 
@@ -21,7 +20,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      issues: write
 
     steps:
     - name: Checkout code
@@ -34,27 +32,16 @@ jobs:
         cache: true
 
     - name: Install govulncheck
-      # Pin to specific version to prevent supply chain attacks (update manually or via Renovate)
       run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
     - name: Run govulncheck
       run: |
-        echo "# govulncheck Security Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Scanning Go code and dependencies for known vulnerabilities..." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
-        # Run govulncheck and capture output
+        echo "# govulncheck Security Scan Results" >> "$GITHUB_STEP_SUMMARY"
         if govulncheck ./... 2>&1 | tee govulncheck-output.txt; then
-          echo "## ✅ No vulnerabilities found!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All Go dependencies are free from known vulnerabilities." >> $GITHUB_STEP_SUMMARY
+          echo "No vulnerabilities found." >> "$GITHUB_STEP_SUMMARY"
         else
-          echo "## ❌ Vulnerabilities detected!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          cat govulncheck-output.txt >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "Vulnerabilities detected:" >> "$GITHUB_STEP_SUMMARY"
+          cat govulncheck-output.txt >> "$GITHUB_STEP_SUMMARY"
           exit 1
         fi
 
@@ -66,10 +53,13 @@ jobs:
         path: govulncheck-output.txt
         retention-days: 30
 
-    - name: Create GitHub issue on vulnerability
+    - name: Report security findings to Jira
       if: failure() && github.event_name != 'pull_request'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_PARENT_KEY: ${{ vars.JIRA_SECURITY_PARENT_KEY }}
+        JIRA_ASSIGNEE_ACCOUNT_ID: ${{ vars.JIRA_ASSIGNEE_ACCOUNT_ID }}
         SERVER_URL: ${{ github.server_url }}
         REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
@@ -77,128 +67,21 @@ jobs:
         SHA: ${{ github.sha }}
         EVENT_NAME: ${{ github.event_name }}
       run: |
-        # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "govulncheck" --json number --jq ".[0].number" 2>/dev/null || echo "")
-
-        if [ -n "$EXISTING_ISSUE" ]; then
-          echo "Existing issue found: #$EXISTING_ISSUE"
-
-          # Build comment body using echo statements to avoid YAML heredoc issues
-          {
-            echo "## 🔄 Vulnerability Still Present"
-            echo ""
-            echo "**New Detection**: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "**Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-            echo "**Branch**: ${REF_NAME}"
-            echo "**Commit**: ${SHA}"
-            echo ""
-            echo "### Latest Scan Output"
-            echo ""
-            echo "<details>"
-            echo "<summary>Click to expand scan results</summary>"
-            echo ""
-            echo "\`\`\`"
-            cat govulncheck-output.txt 2>/dev/null | head -100 || echo "See workflow logs for full details"
-            echo "\`\`\`"
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "**Action Required**: The vulnerabilities listed in this issue are still present. Please prioritize remediation."
-          } > comment_body.md
-
-          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
-        else
-          echo "Creating new issue..."
-
-          # Count vulnerabilities if possible
-          VULN_COUNT=$(grep -c "Vulnerability" govulncheck-output.txt 2>/dev/null || echo "unknown")
-
-          # Build issue body using echo statements to avoid YAML heredoc issues
-          {
-            echo "# 🚨 Security Alert: Go Vulnerabilities Detected"
-            echo ""
-            echo "## Overview"
-            echo ""
-            echo "The **govulncheck** security scanner has detected vulnerabilities in Go dependencies."
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Scanner** | govulncheck (Official Go vulnerability checker) |"
-            echo "| **Status** | ❌ FAILED |"
-            echo "| **Vulnerabilities** | $VULN_COUNT |"
-            echo "| **Workflow Run** | [${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) |"
-            echo "| **Branch** | \`${REF_NAME}\` |"
-            echo "| **Commit** | \`${SHA}\` |"
-            echo "| **Triggered By** | ${EVENT_NAME} |"
-            echo "| **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |"
-            echo ""
-            echo "## 📋 Vulnerability Details"
-            echo ""
-            echo "<details open>"
-            echo "<summary><b>Scan Results (Click to collapse)</b></summary>"
-            echo ""
-            echo "\`\`\`"
-            cat govulncheck-output.txt 2>/dev/null || echo "See workflow run logs for complete details"
-            echo "\`\`\`"
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "## 🔧 Remediation Steps"
-            echo ""
-            echo "### 1️⃣ Review Vulnerabilities"
-            echo "- Examine the scan output above"
-            echo "- Check severity levels and affected packages"
-            echo "- Review [Go Vulnerability Database](https://vuln.go.dev/) for details"
-            echo ""
-            echo "### 2️⃣ Update Dependencies"
-            echo "\`\`\`bash"
-            echo "# Update specific vulnerable package"
-            echo "go get -u <vulnerable-package>@<patched-version>"
-            echo ""
-            echo "# Or update all dependencies (careful - test thoroughly)"
-            echo "go get -u ./..."
-            echo "go mod tidy"
-            echo "\`\`\`"
-            echo ""
-            echo "### 3️⃣ Test Changes"
-            echo "\`\`\`bash"
-            echo "# Run tests"
-            echo "make test"
-            echo ""
-            echo "# Run all security scans"
-            echo "make test-all"
-            echo "\`\`\`"
-            echo ""
-            echo "### 4️⃣ Verify Fix"
-            echo "- Push changes to a branch"
-            echo "- The govulncheck workflow will run automatically"
-            echo "- Verify it passes before merging"
-            echo ""
-            echo "## 📚 Resources"
-            echo ""
-            echo "- [Go Vulnerability Database](https://vuln.go.dev/)"
-            echo "- [govulncheck Documentation](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)"
-            echo "- [Workflow File](${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-govulncheck.yml)"
-            echo ""
-            echo "## 🔔 Next Steps"
-            echo ""
-            echo "1. **Assign** this issue to a developer"
-            echo "2. **Prioritize** based on vulnerability severity"
-            echo "3. **Update** dependencies as outlined above"
-            echo "4. **Test** thoroughly to ensure no regressions"
-            echo "5. **Close** this issue once the workflow passes"
-            echo ""
-            echo "---"
-            echo ""
-            echo "*🤖 This issue was automatically created by the [govulncheck security workflow](${SERVER_URL}/${REPO}/actions/workflows/security-govulncheck.yml)*"
-          } > issue_body.md
-
-          # Create issue with security labels
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "🚨 [govulncheck] Vulnerabilities detected on ${REF_NAME}" \
-            --label "security" \
-            --label "govulncheck" \
-            --body-file issue_body.md || \
-          echo "Failed to create issue, but continuing workflow"
-        fi
+        {
+          echo "Security Alert: Go Vulnerabilities Detected (govulncheck)"
+          echo "Scanner: govulncheck"
+          echo "Status: FAILED"
+          echo "Workflow run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          echo "Branch: ${REF_NAME}"
+          echo "Commit: ${SHA}"
+          echo "Triggered by: ${EVENT_NAME}"
+          echo ""
+          head -200 govulncheck-output.txt 2>/dev/null || echo "See workflow logs for details"
+          echo ""
+          echo "Remediation: review the Go vulnerability database and update affected dependencies."
+          echo "Workflow: ${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-govulncheck.yml"
+        } > jira-report.md
+        ./scripts/report-security-finding.sh \
+          --scanner govulncheck \
+          --summary "[Security][govulncheck] Vulnerabilities detected" \
+          --body-file jira-report.md

--- a/.github/workflows/security-nancy.yml
+++ b/.github/workflows/security-nancy.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "**" ]
   schedule:
-    # Run daily at 3:30 AM UTC
     - cron: '30 3 * * *'
   workflow_dispatch:
 
@@ -21,7 +20,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      issues: write
 
     steps:
     - name: Checkout code
@@ -42,70 +40,34 @@ jobs:
     - name: Run nancy dependency scanner
       id: nancy-scan
       run: |
-        # Install nancy — pin to specific version to prevent supply chain attacks
         go install github.com/sonatype-nexus-community/nancy@v1.2.0
-
-        # Run nancy and capture output
         set +e
         nancy sleuth --loud < go.list 2>&1 | tee nancy-output.txt
         NANCY_EXIT_CODE=$?
         set -e
-
-        # Check for OSS Index API errors (401 Unauthorized, 403 Forbidden, 5xx errors)
         if grep -qE "\[401 Unauthorized\]|\[403 Forbidden\]|\[5[0-9][0-9]" nancy-output.txt; then
-          echo "OSS_INDEX_ERROR=true" >> $GITHUB_ENV
-          echo "NANCY_RESULT=api_error" >> $GITHUB_ENV
-          echo "::warning::Sonatype OSS Index API error detected. This is likely a temporary service issue."
+          echo "NANCY_RESULT=api_error" >> "$GITHUB_ENV"
+          echo "::warning::Sonatype OSS Index API error detected."
         elif [ "$NANCY_EXIT_CODE" -eq 0 ]; then
-          echo "OSS_INDEX_ERROR=false" >> $GITHUB_ENV
-          echo "NANCY_RESULT=success" >> $GITHUB_ENV
+          echo "NANCY_RESULT=success" >> "$GITHUB_ENV"
         else
-          echo "OSS_INDEX_ERROR=false" >> $GITHUB_ENV
-          echo "NANCY_RESULT=vulnerabilities" >> $GITHUB_ENV
+          echo "NANCY_RESULT=vulnerabilities" >> "$GITHUB_ENV"
         fi
-
-        # Store exit code for later steps
-        echo "NANCY_EXIT_CODE=$NANCY_EXIT_CODE" >> $GITHUB_ENV
+        echo "NANCY_EXIT_CODE=$NANCY_EXIT_CODE" >> "$GITHUB_ENV"
       continue-on-error: true
 
     - name: Generate summary
       if: always()
       run: |
-        echo "# nancy Dependency Security Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Scanning Go dependencies for known vulnerabilities using Sonatype OSS Index." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
+        echo "# nancy Dependency Security Scan Results" >> "$GITHUB_STEP_SUMMARY"
         if [ "$NANCY_RESULT" = "success" ]; then
-          echo "## ✅ No vulnerable dependencies found!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "All Go dependencies passed nancy security checks." >> $GITHUB_STEP_SUMMARY
+          echo "No vulnerable dependencies found." >> "$GITHUB_STEP_SUMMARY"
         elif [ "$NANCY_RESULT" = "api_error" ]; then
-          echo "## ⚠️ OSS Index API Error" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Nancy could not complete the scan due to a Sonatype OSS Index API error." >> $GITHUB_STEP_SUMMARY
-          echo "This is typically a temporary service issue and not related to your dependencies." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### What to do" >> $GITHUB_STEP_SUMMARY
-          echo "- Wait and re-run the workflow later" >> $GITHUB_STEP_SUMMARY
-          echo "- Check [OSS Index status](https://ossindex.sonatype.org/)" >> $GITHUB_STEP_SUMMARY
-          echo "- govulncheck provides alternative vulnerability scanning" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Error Details" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-          cat nancy-output.txt >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo "No output captured"
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "OSS Index API error; the scan was not conclusive." >> "$GITHUB_STEP_SUMMARY"
+          cat nancy-output.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || true
         else
-          echo "## ❌ Vulnerable dependencies detected!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Nancy found one or more dependencies with known vulnerabilities." >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Remediation Steps" >> $GITHUB_STEP_SUMMARY
-          echo "1. Review the vulnerabilities in the workflow logs" >> $GITHUB_STEP_SUMMARY
-          echo "2. Update affected dependencies: \`go get -u <package>\`" >> $GITHUB_STEP_SUMMARY
-          echo "3. Run \`go mod tidy\` to clean up" >> $GITHUB_STEP_SUMMARY
-          echo "4. Test thoroughly after updates" >> $GITHUB_STEP_SUMMARY
-          echo "5. Re-run this workflow to verify fixes" >> $GITHUB_STEP_SUMMARY
+          echo "Vulnerable dependencies detected." >> "$GITHUB_STEP_SUMMARY"
+          echo "Update affected dependencies and rerun the scan." >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Upload scan results
@@ -118,219 +80,43 @@ jobs:
           nancy-output.txt
         retention-days: 30
 
-    - name: Create GitHub issue on vulnerability
+    - name: Report security findings to Jira
       if: env.NANCY_RESULT == 'vulnerabilities' && github.event_name != 'pull_request'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_PARENT_KEY: ${{ vars.JIRA_SECURITY_PARENT_KEY }}
+        JIRA_ASSIGNEE_ACCOUNT_ID: ${{ vars.JIRA_ASSIGNEE_ACCOUNT_ID }}
         SERVER_URL: ${{ github.server_url }}
         REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
         REF_NAME: ${{ github.ref_name }}
         SHA: ${{ github.sha }}
-        EVENT_NAME: ${{ github.event_name }}
       run: |
-        # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "nancy" --json number --jq ".[0].number" 2>/dev/null || echo "")
-
-        if [ -n "$EXISTING_ISSUE" ]; then
-          echo "Existing issue found: #$EXISTING_ISSUE"
-
-          # Build comment body using echo statements to avoid YAML heredoc issues
-          {
-            echo "## 🔄 Vulnerable Dependencies Still Present"
-            echo ""
-            echo "**New Detection**: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "**Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-            echo "**Branch**: ${REF_NAME}"
-            echo "**Commit**: ${SHA}"
-            echo ""
-            echo "### Status"
-            echo ""
-            echo "Nancy continues to detect vulnerable Go dependencies from the Sonatype OSS Index."
-            echo ""
-            echo "<details>"
-            echo "<summary>View workflow logs for details</summary>"
-            echo ""
-            echo "Check the [workflow run](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) for specific vulnerable packages and versions."
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "**Action Required**: Update vulnerable dependencies to patched versions."
-          } > comment_body.md
-
-          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
-        else
-          echo "Creating new issue..."
-
-          # Build issue body using echo statements to avoid YAML heredoc issues
-          {
-            echo "# 🚨 Security Alert: Vulnerable Go Dependencies (nancy)"
-            echo ""
-            echo "## Overview"
-            echo ""
-            echo "The **nancy** dependency scanner has detected Go dependencies with known vulnerabilities from the **Sonatype OSS Index**."
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Scanner** | nancy (Sonatype OSS Index) |"
-            echo "| **Status** | ❌ FAILED |"
-            echo "| **Database** | Sonatype OSS Index |"
-            echo "| **Workflow Run** | [${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) |"
-            echo "| **Branch** | \`${REF_NAME}\` |"
-            echo "| **Commit** | \`${SHA}\` |"
-            echo "| **Triggered By** | ${EVENT_NAME} |"
-            echo "| **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |"
-            echo ""
-            echo "## 📋 Vulnerability Details"
-            echo ""
-            echo "Nancy scans your Go dependencies (\`go.list\`) against the Sonatype OSS Index for known security vulnerabilities."
-            echo ""
-            echo "### View Full Results"
-            echo ""
-            echo "Check the [workflow run logs](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) for:"
-            echo "- Specific vulnerable package names"
-            echo "- CVE identifiers"
-            echo "- Vulnerability severity ratings"
-            echo "- Recommended patch versions"
-            echo ""
-            echo "### Dependency List"
-            echo ""
-            echo "The scan analyzed dependencies from \`go.list\`. Download the artifact from the workflow run to see the full dependency tree."
-            echo ""
-            echo "## 🔧 Remediation Steps"
-            echo ""
-            echo "### 1️⃣ Identify Vulnerable Packages"
-            echo ""
-            echo "Review the workflow logs to identify which packages have vulnerabilities:"
-            echo "\`\`\`"
-            echo "Check: https://github.com/${REPO}/actions/runs/${RUN_ID}"
-            echo "\`\`\`"
-            echo ""
-            echo "### 2️⃣ Update Dependencies"
-            echo ""
-            echo "For each vulnerable package:"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# Update specific package to patched version"
-            echo "go get -u <vulnerable-package>@<safe-version>"
-            echo ""
-            echo "# Example:"
-            echo "# go get -u github.com/example/pkg@v1.2.3"
-            echo ""
-            echo "# Update go.mod and go.sum"
-            echo "go mod tidy"
-            echo ""
-            echo "# Verify no broken dependencies"
-            echo "go mod verify"
-            echo "\`\`\`"
-            echo ""
-            echo "### 3️⃣ Check for Breaking Changes"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# Run all tests"
-            echo "go test ./..."
-            echo ""
-            echo "# Or use make"
-            echo "make test"
-            echo "\`\`\`"
-            echo ""
-            echo "### 4️⃣ Run nancy Locally (Optional)"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# Install nancy"
-            echo "go install github.com/sonatype-nexus-community/nancy@v1.2.0"
-            echo ""
-            echo "# Generate dependency list"
-            echo "go list -json -deps ./... > go.list"
-            echo ""
-            echo "# Run nancy scan"
-            echo "nancy sleuth --loud < go.list"
-            echo "\`\`\`"
-            echo ""
-            echo "### 5️⃣ Verify Fix"
-            echo ""
-            echo "- Push your changes to a branch"
-            echo "- The nancy workflow will run automatically"
-            echo "- Verify it passes before merging"
-            echo "- Check that no new vulnerabilities were introduced"
-            echo ""
-            echo "## 💡 Best Practices"
-            echo ""
-            echo "### Keep Dependencies Updated"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# Check for outdated dependencies"
-            echo "go list -u -m all"
-            echo ""
-            echo "# Update all dependencies (careful - test thoroughly)"
-            echo "go get -u ./..."
-            echo "go mod tidy"
-            echo "\`\`\`"
-            echo ""
-            echo "### Use Dependabot"
-            echo ""
-            echo "Consider enabling GitHub Dependabot for automatic dependency updates:"
-            echo "1. Go to repository **Settings** → **Security & analysis**"
-            echo "2. Enable **Dependabot security updates**"
-            echo "3. Enable **Dependabot version updates**"
-            echo ""
-            echo "### Regular Scans"
-            echo ""
-            echo "- Nancy runs daily at 3:30 AM UTC"
-            echo "- Also runs on all PRs and pushes"
-            echo "- Monitor Security tab regularly"
-            echo ""
-            echo "## 📚 Resources"
-            echo ""
-            echo "- [nancy Documentation](https://github.com/sonatype-nexus-community/nancy)"
-            echo "- [Sonatype OSS Index](https://ossindex.sonatype.org/)"
-            echo "- [Go Vulnerability Database](https://vuln.go.dev/)"
-            echo "- [Go Module Documentation](https://go.dev/ref/mod)"
-            echo "- [Workflow File](${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-nancy.yml)"
-            echo ""
-            echo "## 🔄 Comparison with govulncheck"
-            echo ""
-            echo "This repository uses both **nancy** and **govulncheck**:"
-            echo ""
-            echo "| Scanner | Database | Focus |"
-            echo "|---------|----------|-------|"
-            echo "| **nancy** | Sonatype OSS Index | Broader vulnerability database |"
-            echo "| **govulncheck** | Go Vulnerability DB | Official Go vulnerabilities |"
-            echo ""
-            echo "Both scanners complement each other - fix vulnerabilities found by either scanner."
-            echo ""
-            echo "## 🔔 Next Steps"
-            echo ""
-            echo "1. **Review** workflow logs for vulnerable package details"
-            echo "2. **Update** each vulnerable dependency to a safe version"
-            echo "3. **Test** thoroughly to ensure no breaking changes"
-            echo "4. **Verify** nancy scan passes"
-            echo "5. **Close** this issue once resolved"
-            echo ""
-            echo "---"
-            echo ""
-            echo "*🤖 This issue was automatically created by the [nancy security workflow](${SERVER_URL}/${REPO}/actions/workflows/security-nancy.yml)*"
-          } > issue_body.md
-
-          # Create issue with security labels
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "🚨 [nancy] Vulnerable dependencies detected on ${REF_NAME}" \
-            --label "security" \
-            --label "nancy" \
-            --body-file issue_body.md || \
-          echo "Failed to create issue, but continuing workflow"
-        fi
+        {
+          echo "Security Alert: Vulnerable Go Dependencies (nancy)"
+          echo "Scanner: nancy / Sonatype OSS Index"
+          echo "Status: FAILED"
+          echo "Workflow run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          echo "Branch: ${REF_NAME}"
+          echo "Commit: ${SHA}"
+          echo ""
+          head -200 nancy-output.txt 2>/dev/null || echo "See workflow logs for details"
+          echo ""
+          echo "Remediation: update vulnerable dependencies and rerun nancy."
+          echo "Workflow: ${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-nancy.yml"
+        } > jira-report.md
+        ./scripts/report-security-finding.sh \
+          --scanner nancy \
+          --summary "[Security][nancy] Vulnerable dependencies detected" \
+          --body-file jira-report.md
 
     - name: Fail if vulnerabilities found
       if: env.NANCY_RESULT == 'vulnerabilities'
       run: |
-        echo "::error::Nancy detected vulnerable Go dependencies. Review the scan results above."
+        echo "::error::Nancy detected vulnerable Go dependencies."
         exit 1
 
     - name: Warn on API error (non-blocking)
       if: env.NANCY_RESULT == 'api_error'
-      run: |
-        echo "::warning::Nancy scan could not complete due to OSS Index API error."
-        echo "This is a temporary external service issue - the workflow will not fail."
-        echo "Other security scanners (govulncheck, Trivy, gosec) continue to provide coverage."
+      run: echo "::warning::Nancy scan could not complete due to an OSS Index API error."

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "**" ]
   schedule:
-    # Run daily at 3 AM UTC
     - cron: '0 3 * * *'
   workflow_dispatch:
 
@@ -21,7 +20,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-      issues: write
 
     steps:
     - name: Checkout code
@@ -52,47 +50,11 @@ jobs:
     - name: Generate summary
       if: always()
       run: |
-        echo "# Trivy Security Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "Comprehensive security scan for vulnerabilities, misconfigurations, secrets, and dependencies." >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-
+        echo "# Trivy Security Scan Results" >> "$GITHUB_STEP_SUMMARY"
         if [ -f trivy-results.txt ]; then
-          # Count vulnerabilities by severity
-          # Note: grep -c outputs "0" and exits 1 when no matches, so we use || true
-          # to prevent script failure, then default empty values to 0
-          CRITICAL=$(grep -c "CRITICAL" trivy-results.txt 2>/dev/null) || true
-          HIGH=$(grep -c "HIGH" trivy-results.txt 2>/dev/null) || true
-          MEDIUM=$(grep -c "MEDIUM" trivy-results.txt 2>/dev/null) || true
-          LOW=$(grep -c "LOW" trivy-results.txt 2>/dev/null) || true
-          CRITICAL=${CRITICAL:-0}
-          HIGH=${HIGH:-0}
-          MEDIUM=${MEDIUM:-0}
-          LOW=${LOW:-0}
-
-          TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW))
-
-          if [ "$TOTAL" = "0" ]; then
-            echo "## ✅ No vulnerabilities found!" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Repository passed all Trivy security checks." >> $GITHUB_STEP_SUMMARY
-          else
-            echo "## ❌ Vulnerabilities detected: $TOTAL" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "| Severity | Count |" >> $GITHUB_STEP_SUMMARY
-            echo "|----------|-------|" >> $GITHUB_STEP_SUMMARY
-            echo "| 🔴 CRITICAL | $CRITICAL |" >> $GITHUB_STEP_SUMMARY
-            echo "| 🟠 HIGH | $HIGH |" >> $GITHUB_STEP_SUMMARY
-            echo "| 🟡 MEDIUM | $MEDIUM |" >> $GITHUB_STEP_SUMMARY
-            echo "| 🟢 LOW | $LOW |" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### Scan Results" >> $GITHUB_STEP_SUMMARY
-            echo '\`\`\`' >> $GITHUB_STEP_SUMMARY
-            cat trivy-results.txt >> $GITHUB_STEP_SUMMARY
-            echo '\`\`\`' >> $GITHUB_STEP_SUMMARY
-          fi
+          cat trivy-results.txt >> "$GITHUB_STEP_SUMMARY"
         else
-          echo "⚠️ No results file generated" >> $GITHUB_STEP_SUMMARY
+          echo "No results file generated" >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Upload Trivy results (SARIF)
@@ -112,217 +74,36 @@ jobs:
           trivy-results.txt
         retention-days: 30
 
-    - name: Create GitHub issue on vulnerability
+    - name: Report security findings to Jira
       if: steps.trivy-scan.outcome == 'failure' && github.event_name != 'pull_request'
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        JIRA_EMAIL: ${{ secrets.JIRA_EMAIL }}
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_PARENT_KEY: ${{ vars.JIRA_SECURITY_PARENT_KEY }}
+        JIRA_ASSIGNEE_ACCOUNT_ID: ${{ vars.JIRA_ASSIGNEE_ACCOUNT_ID }}
         SERVER_URL: ${{ github.server_url }}
         REPO: ${{ github.repository }}
         RUN_ID: ${{ github.run_id }}
         REF_NAME: ${{ github.ref_name }}
         SHA: ${{ github.sha }}
       run: |
-        # Search for existing open issues with security labels (one issue per scanner type)
-        EXISTING_ISSUE=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "security" --label "trivy" --json number --jq ".[0].number" 2>/dev/null || echo "")
-
-        # Count vulnerabilities by severity
-        CRITICAL=$(grep -o "CRITICAL" trivy-results.txt 2>/dev/null | wc -l || echo "0")
-        HIGH=$(grep -o "HIGH" trivy-results.txt 2>/dev/null | wc -l || echo "0")
-        MEDIUM=$(grep -o "MEDIUM" trivy-results.txt 2>/dev/null | wc -l || echo "0")
-        LOW=$(grep -o "LOW" trivy-results.txt 2>/dev/null | wc -l || echo "0")
-        TOTAL=$((CRITICAL + HIGH + MEDIUM + LOW))
-
-        if [ -n "$EXISTING_ISSUE" ]; then
-          echo "Existing issue found: #$EXISTING_ISSUE"
-
-          # Build comment body using echo statements to avoid YAML heredoc issues
-          {
-            echo "## 🔄 Vulnerabilities Still Present"
-            echo ""
-            echo "**New Detection**: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
-            echo "**Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")"
-            echo "**Branch**: ${REF_NAME}"
-            echo "**Commit**: ${SHA}"
-            echo ""
-            echo "### Current Vulnerability Count"
-            echo ""
-            echo "| Severity | Count |"
-            echo "|----------|-------|"
-            echo "| 🔴 CRITICAL | $CRITICAL |"
-            echo "| 🟠 HIGH | $HIGH |"
-            echo "| 🟡 MEDIUM | $MEDIUM |"
-            echo "| 🟢 LOW | $LOW |"
-            echo "| **TOTAL** | **$TOTAL** |"
-            echo ""
-            echo "### Latest Scan Results"
-            echo ""
-            echo "<details>"
-            echo "<summary>Click to expand Trivy scan output</summary>"
-            echo ""
-            echo "\`\`\`"
-            cat trivy-results.txt 2>/dev/null | head -200 || echo "See workflow logs for full details"
-            echo "\`\`\`"
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "**Action Required**: Vulnerabilities persist. Please prioritize CRITICAL and HIGH severity issues."
-            echo ""
-            echo "**Security Tab**: Check the [Security tab](${SERVER_URL}/${REPO}/security/code-scanning) for detailed SARIF results."
-          } > comment_body.md
-
-          gh issue comment "$EXISTING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file comment_body.md
-        else
-          echo "Creating new issue..."
-
-          # Build issue body using echo statements to avoid YAML heredoc issues
-          {
-            echo "# 🚨 Security Alert: Multiple Vulnerabilities Detected (Trivy)"
-            echo ""
-            echo "## Overview"
-            echo ""
-            echo "The **Trivy** comprehensive security scanner has detected vulnerabilities, misconfigurations, or other security issues."
-            echo ""
-            echo "| Field | Value |"
-            echo "|-------|-------|"
-            echo "| **Scanner** | Trivy (Multi-purpose security scanner) |"
-            echo "| **Status** | ❌ FAILED |"
-            echo "| **🔴 CRITICAL** | $CRITICAL |"
-            echo "| **🟠 HIGH** | $HIGH |"
-            echo "| **🟡 MEDIUM** | $MEDIUM |"
-            echo "| **🟢 LOW** | $LOW |"
-            echo "| **TOTAL** | **$TOTAL** |"
-            echo "| **Workflow Run** | [${RUN_ID}](${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}) |"
-            echo "| **Branch** | \`${REF_NAME}\` |"
-            echo "| **Commit** | \`${SHA}\` |"
-            echo "| **Date** | $(date -u +"%Y-%m-%d %H:%M:%S UTC") |"
-            echo ""
-            echo "## 📊 Severity Breakdown"
-            echo ""
-            echo "\`\`\`"
-            echo "CRITICAL: $CRITICAL issues - ⚠️  IMMEDIATE ACTION REQUIRED"
-            echo "HIGH:     $HIGH issues    - 🔥 High priority, fix soon"
-            echo "MEDIUM:   $MEDIUM issues  - ⚡ Medium priority"
-            echo "LOW:      $LOW issues     - 📝 Low priority"
-            echo "\`\`\`"
-            echo ""
-            echo "## 📋 Detailed Scan Results"
-            echo ""
-            echo "### View in GitHub Security Tab"
-            echo ""
-            echo "🔒 **SARIF Results**: [View in Security Tab](${SERVER_URL}/${REPO}/security/code-scanning)"
-            echo ""
-            echo "The SARIF output has been uploaded to GitHub's Security tab for detailed analysis."
-            echo ""
-            echo "### Scan Output"
-            echo ""
-            echo "<details open>"
-            echo "<summary><b>Trivy Findings (Click to collapse)</b></summary>"
-            echo ""
-            echo "\`\`\`"
-            cat trivy-results.txt 2>/dev/null || echo "See workflow run logs for complete details"
-            echo "\`\`\`"
-            echo ""
-            echo "</details>"
-            echo ""
-            echo "## 🎯 What Trivy Scans"
-            echo ""
-            echo "Trivy checks for:"
-            echo "- ✅ **Vulnerabilities** in dependencies (Go modules, npm, etc.)"
-            echo "- ✅ **Misconfigurations** in IaC files (Kubernetes, Docker, etc.)"
-            echo "- ✅ **Secrets** accidentally committed to the repository"
-            echo "- ✅ **License** compliance issues"
-            echo "- ✅ **Container** image vulnerabilities (if applicable)"
-            echo ""
-            echo "## 🔧 Remediation Steps"
-            echo ""
-            echo "### 1️⃣ Prioritize by Severity"
-            echo ""
-            echo "Focus on CRITICAL and HIGH severity issues first:"
-            echo "1. **CRITICAL**: Fix immediately (potential for severe impact)"
-            echo "2. **HIGH**: Fix within days (significant security risk)"
-            echo "3. **MEDIUM**: Fix within weeks (moderate risk)"
-            echo "4. **LOW**: Fix when convenient (low risk)"
-            echo ""
-            echo "### 2️⃣ Update Vulnerable Dependencies"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# For Go dependencies"
-            echo "go get -u <vulnerable-package>@<safe-version>"
-            echo "go mod tidy"
-            echo ""
-            echo "# Verify updates"
-            echo "go mod verify"
-            echo "\`\`\`"
-            echo ""
-            echo "### 3️⃣ Fix Misconfigurations"
-            echo ""
-            echo "Review and fix any configuration issues identified in:"
-            echo "- Kubernetes YAML files"
-            echo "- Docker configurations"
-            echo "- Infrastructure as Code files"
-            echo ""
-            echo "### 4️⃣ Remove Secrets"
-            echo ""
-            echo "If secrets were detected:"
-            echo "\`\`\`bash"
-            echo "# Remove from current commit"
-            echo "git rm <file-with-secret>"
-            echo ""
-            echo "# Remove from history (DANGEROUS - coordinate with team)"
-            echo "git filter-branch --force --index-filter \\"
-            echo "  'git rm --cached --ignore-unmatch <file-with-secret>' \\"
-            echo "  --prune-empty --tag-name-filter cat -- --all"
-            echo "\`\`\`"
-            echo ""
-            echo "### 5️⃣ Test Changes"
-            echo ""
-            echo "\`\`\`bash"
-            echo "# Run tests"
-            echo "make test"
-            echo ""
-            echo "# Run Trivy locally"
-            echo "docker run --rm -v \$(pwd):/scan aquasec/trivy fs /scan"
-            echo "\`\`\`"
-            echo ""
-            echo "### 6️⃣ Verify Fix"
-            echo ""
-            echo "- Push changes to a branch"
-            echo "- Trivy workflow runs automatically"
-            echo "- Check Security tab for SARIF results"
-            echo "- Verify workflow passes"
-            echo ""
-            echo "## 📚 Resources"
-            echo ""
-            echo "- [Trivy Documentation](https://aquasecurity.github.io/trivy/)"
-            echo "- [Trivy GitHub](https://github.com/aquasecurity/trivy)"
-            echo "- [Security Best Practices](https://aquasecurity.github.io/trivy/latest/docs/best-practices/)"
-            echo "- [GitHub Security Tab](${SERVER_URL}/${REPO}/security)"
-            echo "- [Workflow File](${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-trivy.yml)"
-            echo ""
-            echo "## 🔔 Next Steps"
-            echo ""
-            echo "1. **Review** the Security tab for detailed SARIF results"
-            echo "2. **Triage** by severity (CRITICAL → HIGH → MEDIUM → LOW)"
-            echo "3. **Fix** vulnerabilities and misconfigurations"
-            echo "4. **Remove** any detected secrets"
-            echo "5. **Test** thoroughly"
-            echo "6. **Verify** the scan passes"
-            echo "7. **Close** this issue once resolved"
-            echo ""
-            echo "---"
-            echo ""
-            echo "*🤖 This issue was automatically created by the [Trivy security workflow](${SERVER_URL}/${REPO}/actions/workflows/security-trivy.yml)*"
-          } > issue_body.md
-
-          # Create issue with security labels
-          gh issue create \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "🚨 [Trivy] $TOTAL vulnerabilities detected on ${REF_NAME}" \
-            --label "security" \
-            --label "trivy" \
-            --body-file issue_body.md || \
-          echo "Failed to create issue, but continuing workflow"
-        fi
+        {
+          echo "Security Alert: Vulnerabilities Detected (Trivy)"
+          echo "Scanner: Trivy"
+          echo "Status: FAILED"
+          echo "Workflow run: ${SERVER_URL}/${REPO}/actions/runs/${RUN_ID}"
+          echo "Branch: ${REF_NAME}"
+          echo "Commit: ${SHA}"
+          echo ""
+          head -300 trivy-results.txt 2>/dev/null || echo "See workflow logs for details"
+          echo ""
+          echo "Remediation: review the Security tab, prioritize critical/high findings, and rerun Trivy."
+          echo "Workflow: ${SERVER_URL}/${REPO}/blob/main/.github/workflows/security-trivy.yml"
+        } > jira-report.md
+        ./scripts/report-security-finding.sh \
+          --scanner trivy \
+          --summary "[Security][trivy] Vulnerabilities detected" \
+          --body-file jira-report.md
 
     - name: Fail if vulnerabilities found
       if: steps.trivy-scan.outcome == 'failure'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,25 @@
 
 This directory contains utility scripts used by the CAPI test suite.
 
+## report-security-finding.sh
+
+Reports a security scanner finding to Jira. It searches for an open issue for
+the same scanner under `JIRA_PARENT_KEY`, adds a comment when one exists, and
+creates a new ARO Task otherwise.
+
+```bash
+JIRA_EMAIL=... JIRA_API_TOKEN=... JIRA_PARENT_KEY=ARO-12345 \
+  ./scripts/report-security-finding.sh \
+    --scanner gosec \
+    --summary '[Security][gosec] Security findings detected' \
+    --body-file jira-report.md
+```
+
+The security workflows provide `JIRA_EMAIL` and `JIRA_API_TOKEN` from GitHub
+Secrets and `JIRA_SECURITY_PARENT_KEY` from a repository variable. The helper
+uses Jira v3, the ARO security/component defaults, the configured assignee,
+and the `no-qe` label by default.
+
 ## monitor-cluster-json.sh
 
 **Purpose**: Provides comprehensive JSON output for CAPI cluster status monitoring.

--- a/scripts/report-security-finding.sh
+++ b/scripts/report-security-finding.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Report a security scanner finding to Jira, updating the scanner's existing
+# open issue when possible and creating one otherwise.
+
+set -euo pipefail
+
+JIRA_API_BASE="${JIRA_API_BASE:-https://redhat.atlassian.net/rest/api/3}"
+JIRA_ISSUE_TYPE="${JIRA_ISSUE_TYPE:-Task}"
+JIRA_ASSIGNEE_ACCOUNT_ID="${JIRA_ASSIGNEE_ACCOUNT_ID:-5fabb5fdecdae600685b01d6}"
+JIRA_SECURITY_LABEL="${JIRA_SECURITY_LABEL:-no-qe}"
+JIRA_SECURITY_GROUP="${JIRA_SECURITY_GROUP:-Red Hat Employee}"
+
+usage() {
+    cat <<'USAGE'
+Usage: report-security-finding.sh --scanner NAME --summary SUMMARY --body-file FILE
+
+Required environment variables:
+  JIRA_EMAIL       Jira account email
+  JIRA_API_TOKEN   Jira API token
+  JIRA_PARENT_KEY  Parent Jira issue key
+USAGE
+}
+
+SCANNER=""
+SUMMARY=""
+BODY_FILE=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --scanner)
+            [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+            SCANNER="$2"
+            shift 2
+            ;;
+        --summary)
+            [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+            SUMMARY="$2"
+            shift 2
+            ;;
+        --body-file)
+            [[ $# -ge 2 ]] || { usage >&2; exit 2; }
+            BODY_FILE="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ ! "$SCANNER" =~ ^[a-z0-9_-]+$ ]]; then
+    echo "Invalid scanner name: $SCANNER" >&2
+    exit 2
+fi
+if [[ ! "${JIRA_PARENT_KEY:-}" =~ ^[A-Z]+-[0-9]+$ ]]; then
+    echo "Invalid or missing JIRA_PARENT_KEY" >&2
+    exit 2
+fi
+if [[ -z "$SUMMARY" || ! -f "$BODY_FILE" ]]; then
+    echo "A non-empty summary and an existing body file are required" >&2
+    exit 2
+fi
+
+if [[ -z "${JIRA_EMAIL:-}" || -z "${JIRA_API_TOKEN:-}" ]]; then
+    echo "Jira credentials are not configured; skipping Jira update"
+    exit 0
+fi
+
+echo "::add-mask::${JIRA_API_TOKEN}"
+
+request() {
+    local response curl_exit
+    set +e
+    response=$(curl -sS -L -w $'\n%{http_code}' "$@" 2>&1)
+    curl_exit=$?
+    set -e
+    if [[ $curl_exit -ne 0 ]]; then
+        REQUEST_BODY="$response"
+        REQUEST_STATUS=0
+        return 0
+    fi
+    REQUEST_STATUS="${response##*$'\n'}"
+    REQUEST_BODY="${response%$'\n'*}"
+}
+
+JQL="project = ARO AND parent = ${JIRA_PARENT_KEY} AND summary ~ \"\\\"[Security][${SCANNER}]\\\"\" AND status != Closed"
+request \
+    -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    -G "${JIRA_API_BASE}/search/jql" \
+    --data-urlencode "jql=${JQL}" \
+    --data-urlencode 'fields=key,summary,status' \
+    -H 'Content-Type: application/json'
+
+if [[ "$REQUEST_STATUS" -lt 200 || "$REQUEST_STATUS" -ge 300 ]]; then
+    echo "Warning: Jira search failed (HTTP ${REQUEST_STATUS}); skipping Jira update"
+    exit 0
+fi
+
+EXISTING_KEY=$(jq -r '.issues[0].key // empty' <<< "$REQUEST_BODY" 2>/dev/null || true)
+if [[ -n "$EXISTING_KEY" && ! "$EXISTING_KEY" =~ ^[A-Z]+-[0-9]+$ ]]; then
+    echo "Warning: unexpected Jira issue key; skipping Jira update"
+    exit 0
+fi
+
+DESCRIPTION=$(jq -n --rawfile text "$BODY_FILE" \
+    '{type:"doc",version:1,content:[{type:"paragraph",content:[{type:"text",text:$text}]}]}')
+
+if [[ -n "$EXISTING_KEY" ]]; then
+    COMMENT_PAYLOAD=$(jq -n \
+        --argjson body "$DESCRIPTION" \
+        --arg group "$JIRA_SECURITY_GROUP" \
+        '{body:$body,visibility:{type:"group",value:$group}}')
+
+    request \
+        -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+        -X POST "${JIRA_API_BASE}/issue/${EXISTING_KEY}/comment" \
+        -H 'Content-Type: application/json' \
+        -d "$COMMENT_PAYLOAD"
+    if [[ "$REQUEST_STATUS" -ge 200 && "$REQUEST_STATUS" -lt 300 ]]; then
+        echo "Updated Jira issue: ${EXISTING_KEY}"
+    else
+        echo "Warning: Jira comment failed (HTTP ${REQUEST_STATUS}); continuing"
+    fi
+    exit 0
+fi
+
+ISSUE_PAYLOAD=$(jq -n \
+    --arg parent "$JIRA_PARENT_KEY" \
+    --arg summary "$SUMMARY" \
+    --argjson description "$DESCRIPTION" \
+    --arg issue_type "$JIRA_ISSUE_TYPE" \
+    --arg label "$JIRA_SECURITY_LABEL" \
+    --arg assignee "$JIRA_ASSIGNEE_ACCOUNT_ID" \
+    '{
+      fields: {
+        project: {key:"ARO"},
+        parent: {key:$parent},
+        issuetype: {name:$issue_type},
+        summary: $summary,
+        description: $description,
+        labels: [$label],
+        components: [{id:"37592"}],
+        security: {id:"10034"},
+        assignee: {accountId:$assignee},
+        customfield_10464: {id:"10608"},
+        fixVersions: [{id:"105810"}]
+      }
+    }')
+
+request \
+    -u "${JIRA_EMAIL}:${JIRA_API_TOKEN}" \
+    -X POST "${JIRA_API_BASE}/issue" \
+    -H 'Content-Type: application/json' \
+    -d "$ISSUE_PAYLOAD"
+if [[ "$REQUEST_STATUS" -eq 201 ]]; then
+    ISSUE_KEY=$(jq -r '.key // empty' <<< "$REQUEST_BODY" 2>/dev/null || true)
+    echo "Created Jira issue: ${ISSUE_KEY:-unknown}"
+    echo "https://redhat.atlassian.net/browse/${ISSUE_KEY:-unknown}"
+else
+    echo "Warning: Jira issue creation failed (HTTP ${REQUEST_STATUS}); continuing"
+fi

--- a/scripts/test-report-security-finding.sh
+++ b/scripts/test-report-security-finding.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+cat > "$WORK_DIR/curl" <<'MOCK_CURL'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${MOCK_CURL_LOG}"
+
+case "${MOCK_CURL_MODE}" in
+    create)
+        if [[ "$*" == *"/search/jql"* ]]; then
+            printf '%s\n200\n' '{"issues":[]}'
+        else
+            printf '%s\n201\n' '{"key":"ARO-99999"}'
+        fi
+        ;;
+    existing)
+        if [[ "$*" == *"/search/jql"* ]]; then
+            printf '%s\n200\n' '{"issues":[{"key":"ARO-99998"}]}'
+        else
+            printf '%s\n201\n' '{}'
+        fi
+        ;;
+    search-failure)
+        if [[ "$*" == *"/search/jql"* ]]; then
+            printf '%s\n503\n' '{"error":"unavailable"}'
+        else
+            printf '%s\n201\n' '{"key":"ARO-99997"}'
+        fi
+        ;;
+    *)
+        printf 'unexpected mock mode\n' >&2
+        exit 1
+        ;;
+esac
+MOCK_CURL
+chmod +x "$WORK_DIR/curl"
+
+printf '%s\n' 'security findings detected' > "$WORK_DIR/report.md"
+
+export PATH="$WORK_DIR:$PATH"
+export MOCK_CURL_LOG="$WORK_DIR/curl.log"
+export JIRA_EMAIL='test@example.com'
+export JIRA_API_TOKEN='token'
+export JIRA_PARENT_KEY='ARO-27965'
+export JIRA_ASSIGNEE_ACCOUNT_ID='account-id'
+
+assert_contains() {
+    local expected=$1
+    grep -F -- "$expected" "$MOCK_CURL_LOG" >/dev/null
+}
+
+: > "$MOCK_CURL_LOG"
+export MOCK_CURL_MODE=create
+"$SCRIPT_DIR/report-security-finding.sh" \
+    --scanner gosec \
+    --summary '[Security][gosec] Security findings detected' \
+    --body-file "$WORK_DIR/report.md" > "$WORK_DIR/create.out"
+grep -F 'Created Jira issue: ARO-99999' "$WORK_DIR/create.out" >/dev/null
+assert_contains '/search/jql'
+assert_contains '/issue'
+
+: > "$MOCK_CURL_LOG"
+export MOCK_CURL_MODE=existing
+"$SCRIPT_DIR/report-security-finding.sh" \
+    --scanner gosec \
+    --summary '[Security][gosec] Security findings detected' \
+    --body-file "$WORK_DIR/report.md" > "$WORK_DIR/existing.out"
+grep -F 'Updated Jira issue: ARO-99998' "$WORK_DIR/existing.out" >/dev/null
+assert_contains '/issue/ARO-99998/comment'
+
+: > "$MOCK_CURL_LOG"
+export MOCK_CURL_MODE=search-failure
+"$SCRIPT_DIR/report-security-finding.sh" \
+    --scanner gosec \
+    --summary '[Security][gosec] Security findings detected' \
+    --body-file "$WORK_DIR/report.md" > "$WORK_DIR/failure.out"
+grep -F 'skipping Jira update' "$WORK_DIR/failure.out" >/dev/null
+if grep -F '/issue' "$MOCK_CURL_LOG" | grep -v '/search/jql' >/dev/null; then
+    echo 'search failure must not create or update an issue' >&2
+    exit 1
+fi
+
+echo 'report-security-finding tests passed'

--- a/test/01_check_dependencies_test.go
+++ b/test/01_check_dependencies_test.go
@@ -250,6 +250,9 @@ func TestCheckDependencies_ExternalKubeconfig(t *testing.T) {
 	SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
 	output, err := RunCommand(t, "kubectl", "--context", context, "get", "nodes", "--no-headers")
 	if err != nil {
+		if authErr := DetectKubeconfigAuthError(output + " " + err.Error()); authErr != nil {
+			t.Fatalf("Cannot authenticate to external cluster with context '%s': %v\n%s", context, err, FormatKubeconfigAuthError(authErr))
+		}
 		t.Fatalf("Cannot connect to external cluster with context '%s': %v\n\nEnsure the cluster is accessible and credentials are valid.", context, err)
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2606,6 +2606,89 @@ func FormatNetworkError(info *NetworkErrorInfo) string {
 	return result.String()
 }
 
+// KubeconfigAuthErrorInfo contains structured diagnostics for authentication
+// and authorization failures returned while using a kubeconfig.
+type KubeconfigAuthErrorInfo struct {
+	ErrorType   string   // Short error type identifier.
+	Message     string   // Human-readable error description.
+	Remediation []string // Steps to restore access.
+}
+
+// DetectKubeconfigAuthError analyzes kubectl or oc output for authentication
+// and authorization failures. It deliberately does not classify connectivity
+// errors, which are handled by DetectNetworkError.
+func DetectKubeconfigAuthError(output string) *KubeconfigAuthErrorInfo {
+	lowerOutput := strings.ToLower(output)
+
+	// Expired tokens and client certificates require refreshing the credentials
+	// in the kubeconfig rather than changing Kubernetes RBAC.
+	if strings.Contains(lowerOutput, "token has expired") ||
+		strings.Contains(lowerOutput, "token is expired") ||
+		strings.Contains(lowerOutput, "certificate has expired") ||
+		(strings.Contains(lowerOutput, "client certificate") && strings.Contains(lowerOutput, "expired")) {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "credentials_expired",
+			Message:   "The kubeconfig credentials have expired",
+			Remediation: []string{
+				"Refresh or regenerate the token or client certificate used by the kubeconfig",
+				"For an OpenShift cluster, authenticate again with: oc login <api-url>",
+				"For a managed cluster, retrieve a new kubeconfig from the cluster provider",
+				"Verify the system clock is correct if a valid certificate is reported as expired",
+			},
+		}
+	}
+
+	// Forbidden responses indicate a valid identity with insufficient RBAC.
+	if strings.Contains(lowerOutput, "forbidden") ||
+		(strings.Contains(lowerOutput, "cannot ") && strings.Contains(lowerOutput, " resource")) {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "insufficient_permissions",
+			Message:   "The authenticated identity is not authorized to perform the requested Kubernetes operation",
+			Remediation: []string{
+				"Identify the kubeconfig user or service account: kubectl config view --minify",
+				"Ask a cluster administrator to grant the required Kubernetes RBAC role or role binding",
+				"Confirm the kubeconfig context points to the intended cluster and namespace",
+			},
+		}
+	}
+
+	// Unauthorized responses indicate missing, invalid, or rejected credentials.
+	if strings.Contains(lowerOutput, "unauthorized") ||
+		strings.Contains(lowerOutput, "authentication required") ||
+		strings.Contains(lowerOutput, "invalid bearer token") ||
+		strings.Contains(lowerOutput, "provide credentials") {
+		return &KubeconfigAuthErrorInfo{
+			ErrorType: "authentication_failed",
+			Message:   "The kubeconfig credentials were rejected by the Kubernetes API server",
+			Remediation: []string{
+				"Verify the kubeconfig user, token, or client certificate is valid",
+				"Refresh the credentials or retrieve a new kubeconfig from the cluster provider",
+				"Confirm the kubeconfig context points to the intended cluster",
+			},
+		}
+	}
+
+	return nil
+}
+
+// FormatKubeconfigAuthError formats kubeconfig authentication diagnostics for
+// display in dependency and external-cluster validation failures.
+func FormatKubeconfigAuthError(info *KubeconfigAuthErrorInfo) string {
+	if info == nil {
+		return ""
+	}
+
+	var result strings.Builder
+	fmt.Fprintf(&result, "\n=== Kubeconfig Authentication Error: %s ===\n", info.Message)
+	result.WriteString("\nRemediation steps:\n")
+	for _, step := range info.Remediation {
+		fmt.Fprintf(&result, "  %s\n", step)
+	}
+	result.WriteString("\n")
+
+	return result.String()
+}
+
 // RequireClusterResource skips the test if the CAPI Cluster resource does not exist or is in a Failed phase.
 // Use this at the top of verification tests that depend on earlier deployment phases succeeding.
 func RequireClusterResource(t *testing.T, kubeContext, namespace, clusterName string) {

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -3170,6 +3170,80 @@ func TestFormatNetworkError(t *testing.T) {
 	}
 }
 
+func TestDetectKubeconfigAuthError(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		expectedType string
+		expectNil    bool
+	}{
+		{
+			name:         "expired bearer token",
+			output:       "error: You must be logged in to the server (the provided bearer token has expired)",
+			expectedType: "credentials_expired",
+		},
+		{
+			name:         "expired client certificate",
+			output:       "tls: failed to verify certificate: x509: certificate has expired or is not yet valid",
+			expectedType: "credentials_expired",
+		},
+		{
+			name:         "unauthorized",
+			output:       "Error from server (Unauthorized): the server has asked for the client to provide credentials",
+			expectedType: "authentication_failed",
+		},
+		{
+			name:         "forbidden",
+			output:       "Error from server (Forbidden): pods is forbidden: User cannot list resource pods",
+			expectedType: "insufficient_permissions",
+		},
+		{
+			name:      "unrelated kubectl error",
+			output:    "The connection to the server was refused",
+			expectNil: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := DetectKubeconfigAuthError(tc.output)
+			if tc.expectNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %q", result.ErrorType)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected authentication error, got nil")
+			}
+			if result.ErrorType != tc.expectedType {
+				t.Errorf("error type = %q, expected %q", result.ErrorType, tc.expectedType)
+			}
+			if result.Message == "" || len(result.Remediation) == 0 {
+				t.Error("expected message and remediation steps")
+			}
+		})
+	}
+}
+
+func TestFormatKubeconfigAuthError(t *testing.T) {
+	if got := FormatKubeconfigAuthError(nil); got != "" {
+		t.Fatalf("FormatKubeconfigAuthError(nil) = %q, expected empty string", got)
+	}
+
+	info := &KubeconfigAuthErrorInfo{
+		ErrorType:   "insufficient_permissions",
+		Message:     "The authenticated identity is not authorized to perform the requested Kubernetes operation",
+		Remediation: []string{"Grant the required RBAC role to the kubeconfig identity"},
+	}
+	formatted := FormatKubeconfigAuthError(info)
+	for _, expected := range []string{"Kubeconfig Authentication Error", info.Message, "Remediation steps:", info.Remediation[0]} {
+		if !strings.Contains(formatted, expected) {
+			t.Errorf("formatted error does not contain %q: %s", expected, formatted)
+		}
+	}
+}
+
 // TestHasServicePrincipalCredentials tests the HasServicePrincipalCredentials function.
 func TestHasServicePrincipalCredentials(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Description

Fixes ARO-25824

## Changes Made

- Add a shared Jira v3 reporter with deduplication and safe API-failure handling.
- Migrate gosec, govulncheck, nancy, and Trivy workflows from GitHub Issues to Jira Tasks.
- Remove GitHub Issue write permissions from the security workflows.
- Add focused shell tests and document the JIRA_SECURITY_PARENT_KEY repository variable.

## Configuration Changes

| Variable | Purpose | Default |
|----------|---------|---------|
| JIRA_EMAIL secret | Jira account email | required |
| JIRA_API_TOKEN secret | Jira API token | required |
| JIRA_SECURITY_PARENT_KEY variable | Parent Jira issue for security findings | required |
| JIRA_ASSIGNEE_ACCOUNT_ID variable | Jira assignee account | configured default in helper |

## Additional Notes

- Jira-created issues use the ARO project, Task type, component 37592, security 10034, activity type 10608, fix version 105810, and the allowed no-qe label.
- Full dependency checks remain environment-dependent on Docker and Azure credentials.

## Verification

- `bash scripts/test-report-security-finding.sh`
- `bash -n scripts/report-security-finding.sh scripts/test-report-security-finding.sh`
- Workflow YAML parsing
- `make fmt`
- `make lint` (go vet fallback; golangci-lint unavailable)
- `go test ./test -run TestCheckDependencies_ToolAvailable -count=1`