### PR TITLE
fix: extend workload cluster deployment timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ TEST_VERBOSITY ?= -v
 # The Go step timeouts below are auto-computed as these values + 15m headroom.
 # NOTE: Only the Nm format is supported (e.g., 60m, 90m). Other Go duration
 # formats like "1h" or "2h30m" will break the shell arithmetic below.
-CLUSTER_DEPLOYMENT_TIMEOUT ?= 60m
+CLUSTER_DEPLOYMENT_TIMEOUT ?= 120m
 CLUSTER_DELETION_TIMEOUT ?= 60m
 
 # Validate that timeout values are in minutes-only format (Nm)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The test suite validates naming compliance during the Check Dependencies phase (
 
 ### Test Behavior
 
-- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `60m`). Use minutes format: `60m`, `90m`, `120m` (required by Makefile auto-computation).
+- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `120m`). Use minutes format: `60m`, `90m`, `120m` (required by Makefile auto-computation).
 - `CLUSTER_DELETION_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to be deleted (default: `60m`). Use minutes format: `60m`, `90m`, `120m`.
 - `DEPLOYMENT_TIMEOUT` - **Deprecated**: Legacy timeout variable. Falls back to this if `CLUSTER_DEPLOYMENT_TIMEOUT` / `CLUSTER_DELETION_TIMEOUT` are not set.
 - `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout (default: `30m`). If the deployment makes no progress for this duration, the test fails early instead of waiting for the full timeout. Set to `0` to disable.
@@ -346,7 +346,7 @@ These targets are called by `make test-all` but can be run individually for debu
 
 ```bash
 # Run all tests
-go test -v ./test -timeout 60m
+go test -v ./test -timeout 120m
 
 # Run specific test phase
 go test -v ./test -run TestCheckDependencies
@@ -356,7 +356,7 @@ go test -v ./test -run TestInfrastructure
 DEPLOYMENT_ENV=prod \
 WORKLOAD_CLUSTER_NAME=my-aro-cluster \
 REGION=westus2 \
-go test -v ./test -timeout 60m
+go test -v ./test -timeout 120m
 ```
 
 ### Test Results and Reports

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -572,7 +572,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 				"  2. Check MachinePool status: kubectl --context %s -n %s get machinepool %s -o yaml\n"+
 				"  3. Check cluster conditions: kubectl --context %s -n %s get clusters.cluster.x-k8s.io %s -o yaml\n"+
 				"  4. Check controller logs: kubectl --context %s -n capz-system logs -l control-plane=controller-manager --tail=100\n\n"+
-				"To increase timeout: export DEPLOYMENT_TIMEOUT=60m",
+				"To increase timeout: export DEPLOYMENT_TIMEOUT=120m",
 				elapsed.Round(time.Second),
 				controlPlaneReady, machinePoolReady,
 				context, config.WorkloadClusterNamespace, strings.ToLower(controlPlaneKind), controlPlaneName,

--- a/test/config.go
+++ b/test/config.go
@@ -21,7 +21,7 @@ var (
 const (
 	// DefaultClusterDeploymentTimeout is the default timeout for the in-code polling loop
 	// that waits for the workload cluster to become ready during deployment (Phase 05).
-	DefaultClusterDeploymentTimeout = 60 * time.Minute
+	DefaultClusterDeploymentTimeout = 120 * time.Minute
 
 	// DefaultClusterDeletionTimeout is the default timeout for the in-code polling loop
 	// that waits for the workload cluster to be fully deleted (Phase 07).
@@ -29,7 +29,7 @@ const (
 
 	// DefaultDeploymentTimeout is the legacy default timeout for control plane deployment.
 	// Deprecated: Use DefaultClusterDeploymentTimeout instead.
-	DefaultDeploymentTimeout = 60 * time.Minute
+	DefaultDeploymentTimeout = 120 * time.Minute
 
 	// DefaultASOControllerTimeout is the default timeout for ASO controller manager to become ready.
 	// ASO may take longer than other controllers due to its CRD initialization sequence:
@@ -817,7 +817,7 @@ func getControllerNamespace(useK8S bool, envVar, defaultNS string) string {
 // Resolution order:
 //  1. CLUSTER_DEPLOYMENT_TIMEOUT (new, preferred)
 //  2. DEPLOYMENT_TIMEOUT (legacy, backward compat)
-//  3. DefaultClusterDeploymentTimeout (60m)
+//  3. DefaultClusterDeploymentTimeout (120m)
 func parseClusterDeploymentTimeout() time.Duration {
 	if timeoutStr := os.Getenv("CLUSTER_DEPLOYMENT_TIMEOUT"); timeoutStr != "" {
 		timeout, err := time.ParseDuration(timeoutStr)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2678,7 +2678,7 @@ func IsClusterReady(t *testing.T, kubeContext, namespace, clusterName string) bo
 }
 
 // DefaultClusterReadyTimeout is the default timeout for waiting for a cluster to become ready.
-const DefaultClusterReadyTimeout = 60 * time.Minute
+const DefaultClusterReadyTimeout = 120 * time.Minute
 
 // DefaultClusterReadyPollInterval is the default interval between cluster ready checks.
 const DefaultClusterReadyPollInterval = 30 * time.Second
@@ -2692,7 +2692,7 @@ const DefaultClusterReadyPollInterval = 30 * time.Second
 //   - kubeContext: kubectl context to use (e.g., "kind-capz-tests-stage")
 //   - namespace: namespace where the Cluster resource is located
 //   - clusterName: name of the Cluster resource to check
-//   - timeout: maximum time to wait for the cluster to become ready (use 0 for default of 60m)
+//   - timeout: maximum time to wait for the cluster to become ready (use 0 for default of 120m)
 //
 // Returns nil if the cluster becomes ready, or an error if the timeout is reached or the cluster fails.
 func WaitForClusterReady(t *testing.T, kubeContext, namespace, clusterName string, timeout time.Duration) error {


### PR DESCRIPTION
## Summary
- Increase the default workload-cluster deployment wait from 60m to 120m.
- Keep workload-cluster deletion timeout at 60m.
- Update deployment guidance and timeout examples to match.

## Validation
- Focused timeout/configuration tests passed.
- make test passed (42 passed, 4 expected skips).
- make fmt passed.
- golangci-lint was unavailable; Makefile fallback go vet passed.
- Full integration suite was not used for validation because the local environment lacks the crc-admin context.

Assisted-by: Codex GPT-5 <noreply@anthropic.com>