### PR TITLE
ci: make full cluster timeouts configurable

### DIFF
--- a/.github/workflows/workload-cluster-aro-backplane-2.11.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.11.yml
@@ -5,6 +5,19 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
 
 permissions:
   actions: write
@@ -16,4 +29,6 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-2.11
+      deployment_timeout_minutes: ${{ inputs.deployment_timeout_minutes || 60 }}
+      deletion_timeout_minutes: ${{ inputs.deletion_timeout_minutes || 60 }}
     secrets: inherit

--- a/.github/workflows/workload-cluster-aro-backplane-2.17.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-2.17.yml
@@ -5,6 +5,19 @@ on:
   schedule:
     - cron: '0 4 * * *'
   workflow_dispatch:
+    inputs:
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
 
 permissions:
   actions: write
@@ -16,4 +29,6 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-2.17
+      deployment_timeout_minutes: ${{ inputs.deployment_timeout_minutes || 60 }}
+      deletion_timeout_minutes: ${{ inputs.deletion_timeout_minutes || 60 }}
     secrets: inherit

--- a/.github/workflows/workload-cluster-aro-backplane-5.0.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.0.yml
@@ -6,6 +6,19 @@ on:
   schedule:
     - cron: '0 5 * * *'
   workflow_dispatch:
+    inputs:
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
 
 permissions:
   actions: write
@@ -17,4 +30,6 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-5.0
+      deployment_timeout_minutes: ${{ inputs.deployment_timeout_minutes || 60 }}
+      deletion_timeout_minutes: ${{ inputs.deletion_timeout_minutes || 60 }}
     secrets: inherit

--- a/.github/workflows/workload-cluster-aro-backplane-5.1.yml
+++ b/.github/workflows/workload-cluster-aro-backplane-5.1.yml
@@ -6,6 +6,19 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+    inputs:
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options: ['60', '90', '120']
 
 permissions:
   actions: write
@@ -17,4 +30,6 @@ jobs:
     uses: ./.github/workflows/workload-cluster-aro.yml
     with:
       aro_repo_branch: backplane-5.1
+      deployment_timeout_minutes: ${{ inputs.deployment_timeout_minutes || 60 }}
+      deletion_timeout_minutes: ${{ inputs.deletion_timeout_minutes || 60 }}
     secrets: inherit

--- a/.github/workflows/workload-cluster-aro.yml
+++ b/.github/workflows/workload-cluster-aro.yml
@@ -53,6 +53,24 @@ on:
         required: false
         type: string
         default: ''
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options:
+          - '60'
+          - '90'
+          - '120'
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options:
+          - '60'
+          - '90'
+          - '120'
   workflow_call:
     inputs:
       environment:
@@ -80,6 +98,16 @@ on:
         required: false
         type: string
         default: ''
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: false
+        type: string
+        default: '60'
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: false
+        type: string
+        default: '60'
     secrets:
       QUAY_AUTH:
         required: true
@@ -93,7 +121,8 @@ env:
   ARO_REPO_BRANCH: ${{ inputs.aro_repo_branch }}
   CAPZ_PR_NO: ${{ inputs.capz_pr_no }}
   ASO_PR_NO: ${{ inputs.aso_pr_no }}
-  TEST_TIMEOUT_MINUTES: 120
+  CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES: ${{ inputs.deployment_timeout_minutes || 60 }}
+  CLUSTER_DELETION_TIMEOUT_MINUTES: ${{ inputs.deletion_timeout_minutes || 60 }}
   # Global variables (not environment-specific)
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
 
@@ -142,7 +171,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 280  # GO_STEP_DEPLOY_CRS_TIMEOUT (130m) + GO_STEP_DELETION_TIMEOUT (120m) + overhead (30m)
+    timeout-minutes: 280  # Maximum selectable phase timeouts (120m each) + Go-step headroom and overhead
     environment: ${{ inputs.environment || 'aro-stage' }}
     permissions:
       contents: read
@@ -309,12 +338,13 @@ jobs:
 
     - name: 'Run test-all'
       # Azure credentials and config are set at job level (see env: above)
-      # GO_STEP_DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
+      # Go step timeouts have a 15m buffer over each operation timeout so the deployment
       # loop can produce a graceful t.Fatalf before Go's test timer panics.
       run: |
-        export DEPLOYMENT_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
-        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
-        export GO_STEP_DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
+        export CLUSTER_DEPLOYMENT_TIMEOUT="${CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES}m"
+        export CLUSTER_DELETION_TIMEOUT="${CLUSTER_DELETION_TIMEOUT_MINUTES}m"
+        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES + 15))m"
+        export GO_STEP_DELETION_TIMEOUT="$((CLUSTER_DELETION_TIMEOUT_MINUTES + 15))m"
         make test-all
       continue-on-error: true
       id: phase3

--- a/.github/workflows/workload-cluster-rosa.yml
+++ b/.github/workflows/workload-cluster-rosa.yml
@@ -34,6 +34,24 @@ on:
         options:
           - kind
           - mce
+      deployment_timeout_minutes:
+        description: 'Workload cluster deployment timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options:
+          - '60'
+          - '90'
+          - '120'
+      deletion_timeout_minutes:
+        description: 'Workload cluster deletion timeout (minutes)'
+        required: true
+        type: choice
+        default: '60'
+        options:
+          - '60'
+          - '90'
+          - '120'
 
 permissions:
   contents: read
@@ -43,7 +61,8 @@ env:
   ARO_REPO_URL: https://github.com/marek-veber/cluster-api-installer.git
   ARO_REPO_BRANCH: capi-tests
   ARO_REPO_DIR: /tmp/cluster-api-installer-aro
-  TEST_TIMEOUT_MINUTES: 120
+  CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES: ${{ inputs.deployment_timeout_minutes || 60 }}
+  CLUSTER_DELETION_TIMEOUT_MINUTES: ${{ inputs.deletion_timeout_minutes || 60 }}
   # Global variables (not environment-specific)
   QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
   CAPI_USER: mv2
@@ -93,7 +112,7 @@ jobs:
     needs: check-changes
     if: needs.check-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 280  # GO_STEP_DEPLOY_CRS_TIMEOUT (130m) + GO_STEP_DELETION_TIMEOUT (120m) + overhead (30m)
+    timeout-minutes: 280  # Maximum selectable phase timeouts (120m each) + Go-step headroom and overhead
     environment: ${{ inputs.environment || 'rosa-stage' }}
     permissions:
       contents: read
@@ -261,12 +280,13 @@ jobs:
 
     - name: 'Run test-all'
       # AWS credentials and config are set at job level (see env: above)
-      # GO_STEP_DEPLOY_CRS_TIMEOUT has a 10m buffer over DEPLOYMENT_TIMEOUT so the deployment
+      # Go step timeouts have a 15m buffer over each operation timeout so the deployment
       # loop can produce a graceful t.Fatalf before Go's test timer panics.
       run: |
-        export DEPLOYMENT_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
-        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((TEST_TIMEOUT_MINUTES + 10))m"
-        export GO_STEP_DELETION_TIMEOUT="${TEST_TIMEOUT_MINUTES}m"
+        export CLUSTER_DEPLOYMENT_TIMEOUT="${CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES}m"
+        export CLUSTER_DELETION_TIMEOUT="${CLUSTER_DELETION_TIMEOUT_MINUTES}m"
+        export GO_STEP_DEPLOY_CRS_TIMEOUT="$((CLUSTER_DEPLOYMENT_TIMEOUT_MINUTES + 15))m"
+        export GO_STEP_DELETION_TIMEOUT="$((CLUSTER_DELETION_TIMEOUT_MINUTES + 15))m"
         make test-all
       continue-on-error: true
       id: phase3

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The test suite validates naming compliance during the Check Dependencies phase (
 
 ### Test Behavior
 
-- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `120m`). Use minutes format: `60m`, `90m`, `120m` (required by Makefile auto-computation).
+- `CLUSTER_DEPLOYMENT_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to become ready (default: `60m`). Use minutes format: `60m`, `90m`, `120m` (required by Makefile auto-computation).
 - `CLUSTER_DELETION_TIMEOUT` - How long the in-code polling loop waits for the workload cluster to be deleted (default: `60m`). Use minutes format: `60m`, `90m`, `120m`.
 - `DEPLOYMENT_TIMEOUT` - **Deprecated**: Legacy timeout variable. Falls back to this if `CLUSTER_DEPLOYMENT_TIMEOUT` / `CLUSTER_DELETION_TIMEOUT` are not set.
 - `DEPLOYMENT_STALL_TIMEOUT` - Stall detection timeout (default: `30m`). If the deployment makes no progress for this duration, the test fails early instead of waiting for the full timeout. Set to `0` to disable.
@@ -346,7 +346,7 @@ These targets are called by `make test-all` but can be run individually for debu
 
 ```bash
 # Run all tests
-go test -v ./test -timeout 120m
+go test -v ./test -timeout 60m
 
 # Run specific test phase
 go test -v ./test -run TestCheckDependencies
@@ -356,7 +356,7 @@ go test -v ./test -run TestInfrastructure
 DEPLOYMENT_ENV=prod \
 WORKLOAD_CLUSTER_NAME=my-aro-cluster \
 REGION=westus2 \
-go test -v ./test -timeout 120m
+go test -v ./test -timeout 60m
 ```
 
 ### Test Results and Reports
@@ -528,6 +528,11 @@ The test suite integrates with GitHub Actions:
 - **Check Dependencies** - Dependency checks on every push
 - **Test Setup** - Repository setup validation
 - **Test Kind Cluster** - Kind cluster deployment tests
+
+When manually dispatching a Full Cluster Deployment workflow, choose the
+workload-cluster deployment and deletion timeouts from `60`, `90`, or `120`
+minutes. The defaults are `60` minutes for both operations; scheduled runs use
+those defaults.
 
 **Security Scanning:**
 - **govulncheck** - Go vulnerability scanning

--- a/test/config.go
+++ b/test/config.go
@@ -21,7 +21,7 @@ var (
 const (
 	// DefaultClusterDeploymentTimeout is the default timeout for the in-code polling loop
 	// that waits for the workload cluster to become ready during deployment (Phase 05).
-	DefaultClusterDeploymentTimeout = 120 * time.Minute
+	DefaultClusterDeploymentTimeout = 60 * time.Minute
 
 	// DefaultClusterDeletionTimeout is the default timeout for the in-code polling loop
 	// that waits for the workload cluster to be fully deleted (Phase 07).
@@ -29,7 +29,7 @@ const (
 
 	// DefaultDeploymentTimeout is the legacy default timeout for control plane deployment.
 	// Deprecated: Use DefaultClusterDeploymentTimeout instead.
-	DefaultDeploymentTimeout = 120 * time.Minute
+	DefaultDeploymentTimeout = DefaultClusterDeploymentTimeout
 
 	// DefaultASOControllerTimeout is the default timeout for ASO controller manager to become ready.
 	// ASO may take longer than other controllers due to its CRD initialization sequence:
@@ -817,7 +817,7 @@ func getControllerNamespace(useK8S bool, envVar, defaultNS string) string {
 // Resolution order:
 //  1. CLUSTER_DEPLOYMENT_TIMEOUT (new, preferred)
 //  2. DEPLOYMENT_TIMEOUT (legacy, backward compat)
-//  3. DefaultClusterDeploymentTimeout (120m)
+//  3. DefaultClusterDeploymentTimeout (60m)
 func parseClusterDeploymentTimeout() time.Duration {
 	if timeoutStr := os.Getenv("CLUSTER_DEPLOYMENT_TIMEOUT"); timeoutStr != "" {
 		timeout, err := time.ParseDuration(timeoutStr)

--- a/test/config_test.go
+++ b/test/config_test.go
@@ -272,6 +272,18 @@ func TestParseDeploymentStallTimeout_NegativeDuration(t *testing.T) {
 
 // --- CLUSTER_DEPLOYMENT_TIMEOUT tests ---
 
+func TestTimeoutDefaultsAreCentralized(t *testing.T) {
+	if DefaultClusterDeploymentTimeout != 60*time.Minute {
+		t.Errorf("DefaultClusterDeploymentTimeout = %v, want 60m", DefaultClusterDeploymentTimeout)
+	}
+	if DefaultDeploymentTimeout != DefaultClusterDeploymentTimeout {
+		t.Errorf("DefaultDeploymentTimeout = %v, want deployment default %v", DefaultDeploymentTimeout, DefaultClusterDeploymentTimeout)
+	}
+	if DefaultClusterReadyTimeout != DefaultClusterDeploymentTimeout {
+		t.Errorf("DefaultClusterReadyTimeout = %v, want deployment default %v", DefaultClusterReadyTimeout, DefaultClusterDeploymentTimeout)
+	}
+}
+
 func TestParseClusterDeploymentTimeout_Default(t *testing.T) {
 	for _, key := range []string{"CLUSTER_DEPLOYMENT_TIMEOUT", "DEPLOYMENT_TIMEOUT"} {
 		t.Setenv(key, "")

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2678,7 +2678,7 @@ func IsClusterReady(t *testing.T, kubeContext, namespace, clusterName string) bo
 }
 
 // DefaultClusterReadyTimeout is the default timeout for waiting for a cluster to become ready.
-const DefaultClusterReadyTimeout = 120 * time.Minute
+const DefaultClusterReadyTimeout = DefaultClusterDeploymentTimeout
 
 // DefaultClusterReadyPollInterval is the default interval between cluster ready checks.
 const DefaultClusterReadyPollInterval = 30 * time.Second
@@ -2692,7 +2692,7 @@ const DefaultClusterReadyPollInterval = 30 * time.Second
 //   - kubeContext: kubectl context to use (e.g., "kind-capz-tests-stage")
 //   - namespace: namespace where the Cluster resource is located
 //   - clusterName: name of the Cluster resource to check
-//   - timeout: maximum time to wait for the cluster to become ready (use 0 for default of 120m)
+//   - timeout: maximum time to wait for the cluster to become ready (use 0 for default of 60m)
 //
 // Returns nil if the cluster becomes ready, or an error if the timeout is reached or the cluster fails.
 func WaitForClusterReady(t *testing.T, kubeContext, namespace, clusterName string, timeout time.Duration) error {


### PR DESCRIPTION
## Summary
- Restore the canonical workload-cluster deployment default to 60 minutes.
- Centralize the Go deployment timeout and reuse it for legacy and readiness aliases.
- Add deployment and deletion timeout inputs (60/90/120 minutes) to all Full Cluster Deployment workflows: ARO main, all ARO backplane wrappers, and ROSA.
- Pass distinct deployment and deletion values through reusable workflows.

## Validation
- Centralized timeout regression tests passed.
- Full-cluster workflow YAML parsed successfully.
- make test passed (42 passed, 4 expected skips).
- make fmt passed.
- golangci-lint was unavailable; Makefile fallback go vet passed.

The original timeout PR (#840) was merged while this follow-up was being prepared, so this PR is based on current main.

Assisted-by: Codex GPT-5 <noreply@anthropic.com>