### PR TITLE
fix: validate generated Azure resource group

### DIFF
--- a/test/04_generate_yamls_test.go
+++ b/test/04_generate_yamls_test.go
@@ -295,6 +295,16 @@ func TestInfrastructure_GenerateResources(t *testing.T) {
 	}
 	PrintToTTY("\n")
 
+	if config.HasProvider("aro") {
+		clusterYAMLPath := filepath.Join(outputDir, config.ClusterYAML)
+		if err := ValidateGeneratedResourceGroupFile(config.ResourceGroupName, clusterYAMLPath); err != nil {
+			t.Errorf("generated Azure resource group validation failed for %s: %v", clusterYAMLPath, err)
+			return
+		}
+		PrintToTTY("✅ Generated Azure resource group matches configuration: %s\n\n", config.ResourceGroupName)
+		t.Logf("Generated Azure resource group matches configuration: %s", config.ResourceGroupName)
+	}
+
 	// Mark generation as successful only if no errors occurred
 	if !t.Failed() {
 		infrastructureGenerationSucceeded = true

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -230,6 +230,13 @@ func TestDeployment_ApplyClusterYAMLs(t *testing.T) {
 				file, filePath)
 		}
 
+		if config.HasProvider("aro") && file == config.ClusterYAML {
+			if err := ValidateGeneratedResourceGroupFile(config.ResourceGroupName, filePath); err != nil {
+				t.Fatalf("generated Azure resource group validation failed for %s: %v", filePath, err)
+			}
+			PrintToTTY("✅ Generated Azure resource group matches configuration: %s\n\n", config.ResourceGroupName)
+		}
+
 		PrintToTTY("[%d/%d] Applying %s...\n", i+1, len(expectedFiles), file)
 		t.Logf("Applying %s (%d/%d)", file, i+1, len(expectedFiles))
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -821,6 +821,71 @@ func ExtractMachinePoolNameFromYAML(filePath string) (string, error) {
 	return "", fmt.Errorf("no MachinePool resource found in %s", filePath)
 }
 
+// ExtractResourceGroupNameFromYAML extracts the Azure ResourceGroup name from a
+// multi-document YAML file.
+func ExtractResourceGroupNameFromYAML(filePath string) (string, error) {
+	if _, err := os.Stat(filePath); err != nil {
+		return "", fmt.Errorf("file not accessible: %w", err)
+	}
+
+	// #nosec G304 - filePath comes from test configuration
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	docs := strings.Split(string(data), "---")
+	for _, doc := range docs {
+		doc = strings.TrimSpace(doc)
+		if doc == "" {
+			continue
+		}
+
+		var content map[string]interface{}
+		if err := yaml.Unmarshal([]byte(doc), &content); err != nil {
+			continue
+		}
+
+		kind, ok := content["kind"].(string)
+		if !ok || kind != "ResourceGroup" {
+			continue
+		}
+
+		metadata, ok := content["metadata"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		name, ok := metadata["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+
+		return name, nil
+	}
+
+	return "", fmt.Errorf("no Azure ResourceGroup resource found in %s", filePath)
+}
+
+// ValidateGeneratedResourceGroupName verifies that the generated manifest uses
+// the same resource group as the test configuration.
+func ValidateGeneratedResourceGroupName(configuredName, generatedName string) error {
+	if configuredName != generatedName {
+		return fmt.Errorf("configured resource group %q differs from generated resource group %q", configuredName, generatedName)
+	}
+	return nil
+}
+
+// ValidateGeneratedResourceGroupFile verifies the ResourceGroup in a generated
+// manifest against the configured Azure resource group.
+func ValidateGeneratedResourceGroupFile(configuredName, filePath string) error {
+	generatedName, err := ExtractResourceGroupNameFromYAML(filePath)
+	if err != nil {
+		return err
+	}
+	return ValidateGeneratedResourceGroupName(configuredName, generatedName)
+}
+
 // CheckYAMLConfigMatch verifies that existing YAML files match the current configuration.
 // It extracts the cluster name from the cluster YAML file and compares it with the expected
 // cluster name prefix. This is used to detect configuration mismatches that would cause

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -115,6 +115,98 @@ func TestIsKubectlApplySuccess(t *testing.T) {
 	}
 }
 
+func TestExtractResourceGroupNameFromYAML(t *testing.T) {
+	tests := []struct {
+		name        string
+		yaml        string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:     "extracts Azure resource group",
+			yaml:     "apiVersion: resources.azure.com/v1api20200601\nkind: ResourceGroup\nmetadata:\n  name: capz-tests-71771-resgroup\n",
+			expected: "capz-tests-71771-resgroup",
+		},
+		{
+			name:        "fails when resource group is absent",
+			yaml:        "apiVersion: cluster.x-k8s.io/v1beta1\nkind: Cluster\nmetadata:\n  name: test-cluster\n",
+			expectedErr: "no Azure ResourceGroup resource found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "aro.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0600); err != nil {
+				t.Fatalf("failed to write test YAML: %v", err)
+			}
+
+			name, err := ExtractResourceGroupNameFromYAML(path)
+			if tt.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("ExtractResourceGroupNameFromYAML() error = %v, want substring %q", err, tt.expectedErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ExtractResourceGroupNameFromYAML() unexpected error: %v", err)
+			}
+			if name != tt.expected {
+				t.Errorf("ExtractResourceGroupNameFromYAML() = %q, want %q", name, tt.expected)
+			}
+		})
+	}
+}
+
+func TestValidateGeneratedResourceGroupName(t *testing.T) {
+	tests := []struct {
+		name        string
+		configured  string
+		generated   string
+		expectedErr string
+	}{
+		{
+			name:       "accepts matching resource group",
+			configured: "capz-tests-71771-resgroup",
+			generated:  "capz-tests-71771-resgroup",
+		},
+		{
+			name:        "rejects mismatched resource group",
+			configured:  "capz-tests-3d65d-resgroup",
+			generated:   "capz-tests-71771-resgroup",
+			expectedErr: "configured resource group \"capz-tests-3d65d-resgroup\" differs from generated resource group \"capz-tests-71771-resgroup\"",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGeneratedResourceGroupName(tt.configured, tt.generated)
+			if tt.expectedErr == "" {
+				if err != nil {
+					t.Fatalf("ValidateGeneratedResourceGroupName() unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.expectedErr {
+				t.Fatalf("ValidateGeneratedResourceGroupName() error = %v, want %q", err, tt.expectedErr)
+			}
+		})
+	}
+}
+
+func TestValidateGeneratedResourceGroupFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "aro.yaml")
+	yaml := "apiVersion: resources.azure.com/v1api20200601\nkind: ResourceGroup\nmetadata:\n  name: capz-tests-71771-resgroup\n"
+	if err := os.WriteFile(path, []byte(yaml), 0600); err != nil {
+		t.Fatalf("failed to write test YAML: %v", err)
+	}
+
+	err := ValidateGeneratedResourceGroupFile("capz-tests-3d65d-resgroup", path)
+	if err == nil || !strings.Contains(err.Error(), "configured resource group \"capz-tests-3d65d-resgroup\" differs from generated resource group \"capz-tests-71771-resgroup\"") {
+		t.Fatalf("ValidateGeneratedResourceGroupFile() error = %v, want configured/generated mismatch", err)
+	}
+}
+
 func TestExtractClusterNameFromYAML(t *testing.T) {
 	// Create temporary directory for test files
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Description

Validate that the Azure ResourceGroup rendered in `aro.yaml` matches the resource group configured by capi-tests before deployment.

Fixes ARO-29533

## Changes Made

- Extract the Azure ResourceGroup name from generated multi-document YAML.
- Fail generation and application when configured and generated names differ.
- Validate both fresh generation and idempotent/separate apply paths.
- Add unit tests for extraction, matching, mismatching, and file validation.

## Configuration Changes

No configuration changes.

## Additional Notes

Focused regression tests, `go vet ./...`, and `git diff --check` pass. The full integration package could not run in this environment because Docker, Azure authentication, the installer repository, and a Kind cluster were unavailable.