### PR TITLE
fix: remove extra blank line in deployment test

### DIFF
--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -72,7 +72,6 @@ func TestDeployment_00_CreateNamespace(t *testing.T) {
 // This fail-fast check prevents deploying new clusters alongside stale resources from previous
 // configurations (e.g., when CAPI_USER was changed without cleanup).
 func TestDeployment_01_CheckExistingClusters(t *testing.T) {
-
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode


### PR DESCRIPTION
## Description

Remove the unnecessary blank line after `TestDeployment_01_CheckExistingClusters` opens.

Fixes ARO-24276

## Changes Made

- Removed the extra blank line in `test/05_deploy_crs_test.go`.

## Configuration Changes

None.

## Additional Notes

Validation: `git diff --check`, `gofmt -d`, and `GOCACHE=/tmp/capi-tests-go-cache go test ./test -run '^$'` passed. `make test` reached the checks but reported missing Docker and Azure authentication prerequisites.