### PR TITLE
refactor: centralize kubeconfig setup for external clusters

### DIFF
--- a/test/03_cluster_test.go
+++ b/test/03_cluster_test.go
@@ -528,9 +528,7 @@ func TestKindCluster_01_ClusterReady(t *testing.T) {
 
 	// Set kubeconfig for external cluster mode
 	// (for Kind mode, kubectl defaults to ~/.kube/config)
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	output, err = RunCommand(t, "kubectl", "--context", config.GetKubeContext(), "get", "nodes")
 	if err != nil {
@@ -639,9 +637,7 @@ func TestKindCluster_CAPINamespacesExists(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	PrintToTTY("\n=== Checking for controller namespaces ===\n")
 	t.Log("Checking for controller namespaces...")
@@ -687,9 +683,7 @@ func TestKindCluster_CAPIControllerReady(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -787,9 +781,7 @@ func TestKindCluster_InfraControllersReady(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -889,9 +881,7 @@ func TestKindCluster_WebhooksReady(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 

--- a/test/05_deploy_crs_test.go
+++ b/test/05_deploy_crs_test.go
@@ -22,9 +22,7 @@ func TestDeployment_00_CreateNamespace(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -76,9 +74,7 @@ func TestDeployment_01_CheckExistingClusters(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -132,9 +128,7 @@ func TestDeployment_ApplyResources(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	outputDir := filepath.Join(config.RepoDir, config.GetOutputDirName())
 
@@ -187,9 +181,7 @@ func TestDeployment_ApplyClusterYAMLs(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	outputDir := filepath.Join(config.RepoDir, config.GetOutputDirName())
 
@@ -322,9 +314,7 @@ func TestDeployment_ProviderCredentialsConfigured(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -414,9 +404,7 @@ func TestDeployment_MonitorCluster(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	PrintToTTY("Checking prerequisites...\n")
 	if !DirExists(config.RepoDir) {
@@ -495,9 +483,7 @@ func TestDeployment_WaitForControlPlane(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -851,9 +837,7 @@ func TestDeployment_WaitForExternalAuthReady(t *testing.T) {
 		t.Skip("Skipping ARO-specific test (ExternalAuthReady condition is ARO-specific)")
 	}
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -946,9 +930,7 @@ func TestDeployment_VerifyInfrastructureResources(t *testing.T) {
 	}
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -1053,9 +1035,7 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 		t.Skip("Skipping ARO-specific test (AROCluster resource is not used by this provider)")
 	}
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -1136,9 +1116,7 @@ func TestDeployment_VerifyAROClusterReady(t *testing.T) {
 func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 	config := NewTestConfig()
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -1213,9 +1191,7 @@ func TestDeployment_VerifyClusterProvisioned(t *testing.T) {
 func TestDeployment_VerifyClusterInfrastructureReady(t *testing.T) {
 	config := NewTestConfig()
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()

--- a/test/06_verification_test.go
+++ b/test/06_verification_test.go
@@ -29,9 +29,7 @@ func TestVerification_RetrieveKubeconfig(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -162,9 +160,7 @@ func TestVerification_ClusterNodes(t *testing.T) {
 	}
 
 	// Set KUBECONFIG for external cluster mode (management cluster)
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -343,9 +339,7 @@ func TestVerification_TestedVersionsSummary(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -392,9 +386,7 @@ func TestVerification_ControllerLogSummary(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 

--- a/test/07_deletion_test.go
+++ b/test/07_deletion_test.go
@@ -19,9 +19,7 @@ func TestDeletion_DeleteCluster(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -97,9 +95,7 @@ func TestDeletion_WaitForClusterDeletion(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -254,9 +250,7 @@ func TestDeletion_VerifyControlPlaneDeletion(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -297,9 +291,7 @@ func TestDeletion_VerifyMachinePoolDeletion(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()
@@ -409,9 +401,7 @@ func TestDeletion_VerifyAzureResourcesDeletion(t *testing.T) {
 func TestDeletion_DeleteManagementClusterK8sTestNamespace(t *testing.T) {
 	config := NewTestConfig()
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -472,9 +462,7 @@ func TestDeletion_Summary(t *testing.T) {
 	config := NewTestConfig()
 
 	// Set KUBECONFIG for external cluster mode
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	provisionedClusterName := config.GetProvisionedClusterName()

--- a/test/08_cleanup_test.go
+++ b/test/08_cleanup_test.go
@@ -210,9 +210,7 @@ func TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval(t *testing.T) {
 	PrintTestHeader(t, "TestCleanup_VerifyManagementClusterK8sTestNamespaceRemoval",
 		"Verify workload cluster namespace was removed")
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -251,9 +249,7 @@ func TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces(t *testing.T) 
 	PrintTestHeader(t, "TestCleanup_VerifyOrphanedManagementClusterK8sTestNamespaces",
 		fmt.Sprintf("Check for orphaned test namespaces (label: %s=true)", config.TestLabelPrefix))
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 
@@ -828,9 +824,7 @@ func TestCleanup_Summary(t *testing.T) {
 	// Management cluster namespaces
 	PrintToTTY("\n--- Management Cluster Namespaces ---\n")
 
-	if config.IsExternalCluster() {
-		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
-	}
+	SetupKubeconfig(t, config)
 
 	context := config.GetKubeContext()
 	testNamespaces, nsErr := GetManagementClusterK8sTestNamespaces(t, context)

--- a/test/09_teardown_test.go
+++ b/test/09_teardown_test.go
@@ -21,7 +21,7 @@ func TestTeardown_RevertMCEComponents(t *testing.T) {
 		t.Skip("Not using external cluster (USE_KUBECONFIG not set)")
 	}
 
-	SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	SetupKubeconfig(t, config)
 	context := config.GetKubeContext()
 
 	if !IsMCECluster(t, context) {

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -459,6 +459,14 @@ func SetEnvVar(t *testing.T, key, value string) {
 	})
 }
 
+// SetupKubeconfig sets KUBECONFIG when tests use an external management cluster.
+func SetupKubeconfig(t *testing.T, config *TestConfig) {
+	t.Helper()
+	if config.IsExternalCluster() {
+		SetEnvVar(t, "KUBECONFIG", config.UseKubeconfig)
+	}
+}
+
 // FileExists checks if a file exists at the given path
 func FileExists(path string) bool {
 	_, err := os.Stat(path) // #nosec G703 -- test helper only checks existence, no file content read

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -4480,3 +4480,25 @@ func TestRedactCommand(t *testing.T) {
 		})
 	}
 }
+
+func TestSetupKubeconfig_ExternalCluster(t *testing.T) {
+	t.Setenv("KUBECONFIG", "existing-kubeconfig")
+	config := &TestConfig{UseKubeconfig: "external-kubeconfig"}
+
+	SetupKubeconfig(t, config)
+
+	if got := os.Getenv("KUBECONFIG"); got != config.UseKubeconfig {
+		t.Fatalf("KUBECONFIG = %q, want %q", got, config.UseKubeconfig)
+	}
+}
+
+func TestSetupKubeconfig_LocalCluster(t *testing.T) {
+	t.Setenv("KUBECONFIG", "existing-kubeconfig")
+	config := &TestConfig{}
+
+	SetupKubeconfig(t, config)
+
+	if got := os.Getenv("KUBECONFIG"); got != "existing-kubeconfig" {
+		t.Fatalf("KUBECONFIG = %q, want existing-kubeconfig", got)
+	}
+}


### PR DESCRIPTION
## Description

Extract repeated external-cluster KUBECONFIG setup into a shared test helper.

Jira: https://redhat.atlassian.net/browse/ARO-24277

## Changes Made

- Added and tested `SetupKubeconfig(t, config)`.
- Replaced duplicated setup across cluster, deployment, verification, deletion, cleanup, and teardown tests.
- Preserved local-cluster behavior without changing KUBECONFIG.

## Configuration Changes

No configuration changes.

## Additional Notes

Targeted tests and `go vet` pass. `make test` is environment-blocked by missing Docker and Azure authentication.